### PR TITLE
Use the word label rather than tag for the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ _Describe how you tested the changes_
 
 _~~Strike~~ inapplicable items_
 
-- [ ] Issues linked / tags applied
+- [ ] Issues linked / labels applied
 - [ ] Documentation updated
 - [ ] Tests added / updated / removed
 - [ ] Tests passed


### PR DESCRIPTION
## Summary

PRs should have GitHub _labels_ applied rather than tags because tags are also a `git` feature.

## Checklist

_~~Strike~~ inapplicable items_

- [ ] ~~Issues linked / tags applied~~
- [x] Documentation updated
- [ ] ~~Tests added / updated / removed~~
- [ ] ~~Tests passed~~
- [ ] ~~Analyzers passed~~
- [ ] Ready to complete
