### PR TITLE
Use the inbox label for issues created from the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report and track in Issues
 title: ''
-labels: ''
+labels: 'inbox'
 assignees: wireddown
 
 ---


### PR DESCRIPTION
## Summary

Add `inbox` to the `labels` list in the bug report template. Contributors can [filter for this label](https://github.com/wireddown/qt-py-s3-daq-app/labels/inbox) when browsing for new bug reports.
