### PR TITLE
Add VS Code settings for debugging and testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // https://code.visualstudio.com/docs/python/debugging#_set-configuration-options
+            "name": "qtpy_datalogger [with args]",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "qtpy_datalogger",
+            // Update the arugments to match the debug case
+            "args": [
+                // "--verbose",
+                "run",
+                // "--help",
+            ],
+            // Useful options to enable in some situations
+            "stopOnEntry": false,
+            "autoReload": {
+                "enable": false
+            },
+        },
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    // https://code.visualstudio.com/docs/python/testing#_test-configuration-settings
+    "python.testing.pytestEnabled": true,
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,24 @@
 """Tests for the qtpy_datalogger package entry points."""
 
 import importlib
-import pathlib
 import runpy
+import sys
+from contextlib import contextmanager
 
 import pytest
 
-this_file = pathlib.Path(__file__).resolve()
+
+@contextmanager
+def program_args(args: list[str] | None = None):  # noqa: ANN201
+    """Use the specified args as sys.argv[1:] during a with: statement."""
+    old_sys_args = sys.argv
+    try:
+        args = args if args else []
+        new_sys_args = [sys.argv[0], *args]
+        sys.argv = new_sys_args
+        yield
+    finally:
+        sys.argv = old_sys_args
 
 
 def test_import_as_module():  # noqa: ANN201
@@ -16,7 +28,10 @@ def test_import_as_module():  # noqa: ANN201
 
 def test_run_as_module(capsys):  # noqa: ANN001, ANN201
     """Can Python invoke the entry point?"""
-    with pytest.raises(SystemExit):
+    with (
+        pytest.raises(SystemExit),
+        program_args(),
+    ):
         runpy.run_module("qtpy_datalogger", run_name="__main__")
     captured = capsys.readouterr()
     assert "Show this message and exit" in captured.out, "main did not print the help message"


### PR DESCRIPTION
## Summary

This change introduces VS Code settings files that enable `F5` debugging and `pytest` testing.

## Design

- Add new file `launch.json` with an example configuration that debugs the module
- Add new file `settings.json` that enables `pytest` testing for this workspace

## Screenshots or logs

### Debugging demo

![run-debugger](https://github.com/user-attachments/assets/c219cdbf-c60f-4da9-aab5-266144e5fc06)

### Testing demo

![run-tests](https://github.com/user-attachments/assets/83477d6b-f6ed-4825-b8f2-c2d8a19e923e)

## Testing

- Updated `test_main::test_run_as_module` to support running tests from VS Code
  - When it runs the tests, VS Code adds many options to its invocation of `pytest`
  - Consequently, the `sys.args` array carries options that the `qtpy_datalogger` module doesn't accept
  - Add a `contextmanager` helper that allows overriding the `sys.args` and use it in the test

## Checklist

- [ ] ~~Issues linked / labels applied~~
- [x] Documentation updated
  - Added new stub wiki page: [How-to Guide](https://github.com/wireddown/qt-py-s3-daq-app/wiki/How%E2%80%90to-Guide)
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
