### PR TITLE
Enable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    labels:
+      - "inbox"


### PR DESCRIPTION
## Summary

This change enables the [`dependabot` service](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) that automatically checks for new dependency versions and opens a PR if any are found.

## Design

Followed the [documentation and examples](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) to create `dependabot.yml`.

## Screenshots or logs

_pending_

## Testing

_pending_

## Checklist

- [ ] ~~Issues linked / labels applied~~
- [x] Documentation updated
- [ ] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
