### PR TITLE
Enable more linter rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ extend-select = [
     "T10",
     "T20",
     "TD",
+    "TRY",
     "UP",
     "W",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ extend-select = [
     "S",
     "SIM",
     "T10",
+    "T20",
     "UP",
     "W",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ extend-select = [
     "SIM",
     "T10",
     "T20",
+    "TD",
     "UP",
     "W",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ extend-select = [
     "ISC",
     "LOG",
     "N",
+    "NPY",
+    "PD",
     "PL",
     "PIE",
     "PT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ extend-select = [
     "C4",
     "COM",
     "D",
+    "DTZ",
     "EM",
     "G",
     "I",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ ignore = [
     "G004",
     "ISC001",
     "RET504",
+    "TD002",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ extend-select = [
     "D",
     "DTZ",
     "EM",
+    "ERA",
     "G",
     "I",
     "ICN",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ extend-select = [
     "DTZ",
     "EM",
     "ERA",
+    "FURB",
     "G",
     "I",
     "ICN",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ extend-exclude = [
 extend-select = [
     "A",
     "ANN",
+    "ASYNC",
     "B",
     "BLE",
     "C4",

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -23,7 +23,7 @@ def test_subcommand():  # noqa: ANN201
 
     @click.command("subcommand_name")
     def subcommand_name() -> None:
-        print(command_was_invoked_message)
+        print(command_was_invoked_message)  # noqa: T201 Allow print for this test
 
     console.cli.add_command(subcommand_name)
 


### PR DESCRIPTION
## Summary

This change enables more linter rules to prevent misuse of several Python features.
- asynchronous operations
- time and numeric libraries
- print vs logging
- built-ins like try and raise
- outdated Python conventions

## Design

Enable the rules in ruff by adding to the `extend-select` list.

## Screenshots or logs

🚫

## Testing

No new tests, rely on the CI workflow to run them.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] ~~Tests passed~~
- [x] Analyzers passed
- [x] Ready to complete
