### PR TITLE
Add pysh to sensor node bundle

### DIFF
--- a/src/qtpy_sensor_node/qtpy_sensor_node.md
+++ b/src/qtpy_sensor_node/qtpy_sensor_node.md
@@ -1,0 +1,40 @@
+# QTPy Sensor Node
+
+This folder and its subfolders are an overlay for a CircuitPython device.
+The code adds functions to perform data logging from analog channels and I2C devices.
+
+See the source code at https://github.com/wireddown/qt-py-s3-daq-app.
+
+## Manual bringup
+
+1. Copy this folder and its subfolders to the QT Py S3
+1. Update `code.py` to use the new code
+
+### Terminal shell
+
+This example demonstrates a console for a serial device.
+
+`code.py`
+
+```python
+import gc
+import usb_cdc
+
+from snsr.pysh.py_shell import PromptSession
+
+serial = usb_cdc.console
+if usb_cdc.data:
+    print("Switching to usb_cdc.data for serial IO with host")
+    serial = usb_cdc.data
+else:
+    print("Using sys.stdio for serial IO with host")
+
+session = PromptSession(in_stream=serial, out_stream=serial)
+
+while True:
+    used_bytes = gc.mem_alloc()
+    free_bytes = gc.mem_free()
+    response = session.prompt(f"[{used_bytes / 1024:.3f} kB {free_bytes / 1024:.3f} kB] ")
+
+    print(f"(echo)\n{response}", file=serial)
+```

--- a/src/qtpy_sensor_node/snsr/pysh/__init__.py
+++ b/src/qtpy_sensor_node/snsr/pysh/__init__.py
@@ -1,0 +1,1 @@
+"""Python shell 'pysh' package."""

--- a/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
@@ -81,7 +81,7 @@ class TracedWriter:
 
 
 class IOTracer:
-    """An IO stream tracer that logs bytes read and written to the streams."""
+    """An IO stream tracer that logs bytes read from and written to the streams."""
 
     def __init__(self, input_stream: BinaryIO, output_stream: BinaryIO) -> None:
         """Create an IOTracer that logs all IO with input_stream and output_stream."""

--- a/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
@@ -194,7 +194,7 @@ def builtin_input(message: str = "") -> str:
     return from_remote
 
 
-# Can we set a new wrapped fuction on the serial object?
+# Can we set a new wrapped function on the serial object?
 # - AttributeError: can't set attribute 'write'
 def traced(traced_function: Callable, trace_list: list[str]) -> Callable:
     """When traced_function is called, add a message containing the parameters to trace_list."""

--- a/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
@@ -11,9 +11,10 @@ from .py_shell import (
     ORD_NUL,
     ORD_OPEN_BRACKET,
     ORD_SEMICOLON,
-    ORD_TAB,
     PromptSession,
 )
+
+from .linebuffer import ORD_TAB
 
 try:  # noqa: SIM105 -- contextlib is not available for CircuitPython
     from typing import BinaryIO, Callable

--- a/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
@@ -113,7 +113,15 @@ class TracedSession:
     """A traced shell-like session for multiple interactive prompts that supports line editing."""
 
     def __init__(self, in_stream: BinaryIO, out_stream: BinaryIO, autoecho: bool = True) -> None:
-        """."""
+        """
+        Create a TracedSession using in_stream and out_stream for IO.
+
+        Before returning the user's response, this session prints the control codes sent and
+        received before the user completed their response with the enter key.
+
+        If you set autoecho to False, you must manage the size of the tracer's traced_io_log. Otherwise
+        the QT Py runs out of memory and exits with an allocation error.
+        """
         self._autoecho = autoecho
         self._tracer = IOTracer(input_stream=in_stream, output_stream=out_stream)
         self._session = PromptSession(
@@ -122,7 +130,7 @@ class TracedSession:
         )
 
     def prompt(self, message: str) -> bytes:
-        """."""
+        """Prompt the user for input with the given message."""
         response = self._session.prompt(message)
         if self._autoecho and self._tracer.traced_io_log:
             _ = [print(entry) for entry in self._tracer.traced_io_log]  # noqa: T201 -- use builtin to bypass self-tracing
@@ -131,7 +139,7 @@ class TracedSession:
 
     @property
     def tracer(self) -> IOTracer:
-        """."""
+        """Return the IOTracer object capturing the input and output stream bytes."""
         return self._tracer
 
 

--- a/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
@@ -1,0 +1,198 @@
+"""Classes and functions for inspecting and tracing the shell's IO."""
+
+from .py_shell import (
+    ORD_BACKSPACE,
+    ORD_CR,
+    ORD_DEL,
+    ORD_EOF,
+    ORD_ESC,
+    ORD_FKEY_START,
+    ORD_LF,
+    ORD_NUL,
+    ORD_OPEN_BRACKET,
+    ORD_SEMICOLON,
+    ORD_TAB,
+    PromptSession,
+)
+
+try:  # noqa: SIM105 -- contextlib is not available for CircuitPython
+    from typing import BinaryIO, Callable
+except ImportError:
+    pass
+
+_PRINTABLE_FOR_NONPRINTABLE = {
+    ORD_NUL: "(0)",
+    ORD_FKEY_START: "(F)",
+    ORD_BACKSPACE: "BS",
+    ORD_TAB: "TAB",
+    ORD_LF: "LF",
+    ORD_CR: "CR",
+    ORD_EOF: "EOF",
+    ORD_ESC: "ESC",
+    ORD_DEL: "DEL",
+}
+
+
+class TracedReader:
+    """A stream reader that logs bytes read from the stream."""
+
+    def __init__(self, input_stream: BinaryIO, shared_tracelog: list[str], log_prefix: str | None = None) -> None:
+        """
+        Create a TracedReader that logs all reads from input_stream into shared_tracelog.
+
+        input_stream must support a function with signature 'read(int) -> bytes'.
+        """
+        self._input_stream = input_stream
+        self._shared_tracelog = shared_tracelog
+        self._log_prefix = log_prefix if log_prefix is not None else type(self)
+        self._trace(f"tracing input from {type(input_stream)}")
+
+    def read(self, byte_count: int) -> bytes:
+        """Read from the input_stream and log it."""
+        input_chars = self._input_stream.read(byte_count)
+        self._trace(f" in   {input_chars}")
+        return input_chars
+
+    def _trace(self, message: str) -> None:
+        self._shared_tracelog.append(f"{self._log_prefix}{message}")
+
+
+class TracedWriter:
+    """A stream writer that logs bytes written to the stream."""
+
+    def __init__(self, output_stream: BinaryIO, shared_tracelog: list[str], log_prefix: str | None = None) -> None:
+        """
+        Create a TracedWriter that logs all writes to output_stream into shared_tracelog.
+
+        output_stream must support a function with signature 'write(bytes) -> None'.
+        """
+        self._output_stream = output_stream
+        self._shared_tracelog = shared_tracelog
+        self._log_prefix = log_prefix if log_prefix is not None else type(self)
+        self._trace(f"tracing output from {type(output_stream)}")
+
+    def write(self, encoded_string: bytes) -> None:
+        """Read to the output_stream and log it."""
+        self._trace(f"out > {encoded_string}")
+        self._output_stream.write(encoded_string)
+
+    def _trace(self, message: str) -> None:
+        self._shared_tracelog.append(f"{self._log_prefix}{message}")
+
+
+class IOTracer:
+    """An IO stream tracer that logs bytes read and written to the streams."""
+
+    def __init__(self, input_stream: BinaryIO, output_stream: BinaryIO) -> None:
+        """Create an IOTracer that logs all IO with input_stream and output_stream."""
+        self._shared_tracelog = []
+        self._traced_input = TracedReader(input_stream, self._shared_tracelog, log_prefix="")
+        self._traced_output = TracedWriter(output_stream, self._shared_tracelog, log_prefix="")
+
+    @property
+    def input_stream(self) -> TracedReader:
+        """Return the TracedReader used by the IOTracer."""
+        return self._traced_input
+
+    @property
+    def output_stream(self) -> TracedWriter:
+        """Return the TracedWriter used by the IOTracer."""
+        return self._traced_output
+
+    @property
+    def traced_io_log(self) -> list[str]:
+        """Return a copy of the logged IO traces from the streams."""
+        return self._shared_tracelog.copy()
+
+    def clear_log(self) -> None:
+        """Clear the trace log."""
+        self._shared_tracelog.clear()
+
+
+class TracedSession():
+    """A traced shell-like session for multiple interactive prompts that supports line editing."""
+
+    def __init__(self, in_stream, out_stream, autoecho=True) -> None:
+        """."""
+        self._autoecho = autoecho
+        self._tracer = IOTracer(input_stream=in_stream, output_stream=out_stream)
+        self._session = PromptSession(
+            in_stream=self._tracer.input_stream,
+            out_stream=self._tracer.output_stream
+        )
+
+    def prompt(self, message: str) -> bytes:
+        """."""
+        response = self._session.prompt(message)
+        if self._autoecho:
+            if self._tracer.traced_io_log:
+                _ = [print(entry) for entry in self._tracer.traced_io_log]
+                self._tracer.clear_log()
+        return response.encode("UTF-8")
+
+    @property
+    def tracer(self) -> IOTracer:
+        """."""
+        return self._tracer
+
+
+def is_printable(char_ord: int) -> bool:
+    """Return true if the specified ordinal is printable in a terminal."""
+    # https://ss64.com/ascii.html
+    return char_ord > 31 and char_ord < 127  # noqa: PLR2004 -- ordinals /are/ magic numbers
+
+
+def debug_str(in_ordinal: int) -> str:
+    """Return a printable substitute for a non-printable ordinal."""
+    return chr(in_ordinal) if is_printable(in_ordinal) else _PRINTABLE_FOR_NONPRINTABLE.get(in_ordinal, "?")
+
+
+def console_query(
+    query_sequence_ords: list[int], out_stream: BinaryIO, in_stream: BinaryIO, stop_ord: int
+) -> list[int]:
+    """Send the query_sequence_ords to the remote console and return its response."""
+    out_stream.write(bytes(query_sequence_ords))
+    in_ord = ORD_NUL
+    response_ords = []
+    while in_ord != stop_ord:
+        in_char = in_stream.read(1)
+        in_ord = ord(in_char)
+        response_ords.append(in_ord)
+    return response_ords
+
+
+def get_cursor_column(output: BinaryIO, in_stream: BinaryIO) -> int:
+    """Get the cursor column from the remote console."""
+    cursor_position_codes = console_query(
+        query_sequence_ords=[ORD_ESC, ORD_OPEN_BRACKET, ord("6"), ord("n")],
+        out_stream=output,
+        in_stream=in_stream,
+        stop_ord=ord("R"),
+    )
+    # Full response has format ESC[#;#R
+    clipped = cursor_position_codes[2:-1]
+    semicolon_index = clipped.index(ORD_SEMICOLON)
+    column_ords = clipped[semicolon_index + 1 :]
+    return int(bytes(column_ords))
+
+# Can we use input() to get a whole client-side edited line?
+# - input() does     line editing
+#           does     autocomplete on Python globals() with tab (not configurable)
+#           does     support UTF-8 characters
+#           does not support the F-keys but echoes the printable control codes and homes the cursor
+def builtin_input(message: str = "") -> str:
+    """Use the built-in 'input' function to prompt the user with message and return the response."""
+    from_remote = input(message)
+    return from_remote
+
+
+# Can we set a new wrapped fuction on the serial object?
+# - AttributeError: can't set attribute 'write'
+def traced(traced_function: Callable, trace_list: list[str]) -> Callable:
+    """When traced_function is called, add a message containing the parameters to trace_list."""
+
+    def with_tracing(*args, **kwargs) -> Callable:  # noqa: ANN002 ANN003 -- wrapping an unknown function signature
+        trace_list.append(f"{args} {kwargs}")
+        return traced_function(*args, **kwargs)
+
+    return with_tracing

--- a/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_sensor_node/snsr/pysh/diagnostics.py
@@ -1,16 +1,16 @@
 """Classes and functions for inspecting and tracing the shell's IO."""
 
 from .py_shell import (
-    ORD_BACKSPACE,
-    ORD_CR,
-    ORD_DEL,
-    ORD_EOF,
-    ORD_ESC,
-    ORD_FKEY_START,
-    ORD_LF,
-    ORD_NUL,
-    ORD_OPEN_BRACKET,
-    ORD_SEMICOLON,
+    _ORD_BACKSPACE,
+    _ORD_CR,
+    _ORD_DEL,
+    _ORD_EOF,
+    _ORD_ESC,
+    _ORD_FKEY_START,
+    _ORD_LF,
+    _ORD_NUL,
+    _ORD_OPEN_BRACKET,
+    _ORD_SEMICOLON,
     PromptSession,
 )
 
@@ -22,15 +22,15 @@ except ImportError:
     pass
 
 _PRINTABLE_FOR_NONPRINTABLE = {
-    ORD_NUL: "(0)",
-    ORD_FKEY_START: "(F)",
-    ORD_BACKSPACE: "BS",
+    _ORD_NUL: "(0)",
+    _ORD_FKEY_START: "(F)",
+    _ORD_BACKSPACE: "BS",
     ORD_TAB: "TAB",
-    ORD_LF: "LF",
-    ORD_CR: "CR",
-    ORD_EOF: "EOF",
-    ORD_ESC: "ESC",
-    ORD_DEL: "DEL",
+    _ORD_LF: "LF",
+    _ORD_CR: "CR",
+    _ORD_EOF: "EOF",
+    _ORD_ESC: "ESC",
+    _ORD_DEL: "DEL",
 }
 
 
@@ -153,7 +153,7 @@ def console_query(
 ) -> list[int]:
     """Send the query_sequence_ords to the remote console and return its response."""
     out_stream.write(bytes(query_sequence_ords))
-    in_ord = ORD_NUL
+    in_ord = _ORD_NUL
     response_ords = []
     while in_ord != stop_ord:
         in_char = in_stream.read(1)
@@ -165,14 +165,14 @@ def console_query(
 def get_cursor_column(output: BinaryIO, in_stream: BinaryIO) -> int:
     """Get the cursor column from the remote console."""
     cursor_position_codes = console_query(
-        query_sequence_ords=[ORD_ESC, ORD_OPEN_BRACKET, ord("6"), ord("n")],
+        query_sequence_ords=[_ORD_ESC, _ORD_OPEN_BRACKET, ord("6"), ord("n")],
         out_stream=output,
         in_stream=in_stream,
         stop_ord=ord("R"),
     )
     # Full response has format ESC[#;#R
     clipped = cursor_position_codes[2:-1]
-    semicolon_index = clipped.index(ORD_SEMICOLON)
+    semicolon_index = clipped.index(_ORD_SEMICOLON)
     column_ords = clipped[semicolon_index + 1 :]
     return int(bytes(column_ords))
 

--- a/src/qtpy_sensor_node/snsr/pysh/linebuffer.py
+++ b/src/qtpy_sensor_node/snsr/pysh/linebuffer.py
@@ -1,0 +1,136 @@
+"""A user input buffer for line editing."""
+
+ORD_TAB = 0x09
+
+
+class LineBuffer:
+    """A user input buffer that supports tabs, moving the cursor, deleting, and backspacing."""
+
+    def __init__(self, prompt_length: int, tab_size: int = 8) -> None:
+        """Create a new LineBuffer for interactive user input."""
+        self._first_terminal_column = 1
+        self.prompt_length = prompt_length
+        self.tab_size = tab_size
+        self.ord_codes = []
+        self.input_cursor = 0
+        self.terminal_column = self._get_column_at_cursor()
+
+    def has_bytes(self) -> bool:
+        """Return whether the buffer has contents."""
+        return len(self.ord_codes) > 0
+
+    def get_decoded_bytes(self) -> str:
+        """Get the buffer as a UTF-8 string."""
+        return bytes(self.ord_codes).decode("UTF-8")
+
+    def get_terminal_column(self) -> int:
+        """Return the terminal column of the input cursor."""
+        return self.terminal_column
+
+    def accept(self, ord_code: int) -> tuple[int, list[int]]:
+        """
+        Insert a new ordinate at the input cursor.
+
+        Returns a tuple of the new terminal column and a slice of the
+        input buffer from the new ordinate to the end of the buffer.
+        """
+        self.ord_codes.insert(self.input_cursor, ord_code)
+        code_with_remaining_line = self.ord_codes[self.input_cursor :]
+        self.input_cursor += 1
+        self.terminal_column = self._get_column_at_cursor()
+        return self.terminal_column, code_with_remaining_line
+
+    def delete(self) -> tuple[int, list[int]]:
+        """
+        Delete the ordinate after the input cursor.
+
+        Returns a tuple of the new terminal column and a slice of the
+        input buffer from the cursor to the end of the buffer.
+        """
+        if self.input_cursor < len(self.ord_codes):
+            _ = self.ord_codes.pop(self.input_cursor)
+            self.terminal_column = self._get_column_at_cursor()
+        remaining_line = self.ord_codes[self.input_cursor :]
+        return self.terminal_column, remaining_line
+
+    def backspace(self) -> tuple[int, list[int]]:
+        """
+        Delete the ordinate before the input cursor.
+
+        Returns a tuple of the new terminal column and a slice of the
+        input buffer from the cursor to the end of the buffer.
+        """
+        old_column = self.terminal_column
+        new_column = self.move_left()
+        if new_column != old_column:
+            self.delete()
+        remaining_line = self.ord_codes[self.input_cursor :]
+        return new_column, remaining_line
+
+    def move_home(self) -> int:
+        """
+        Move the input cursor to the beginning of the buffer.
+
+        Returns the new terminal column of the input cursor.
+        """
+        self.input_cursor = 0
+        self.terminal_column = self._get_column_at_cursor()
+        return self.terminal_column
+
+    def move_end(self) -> int:
+        """
+        Move the input cursor to the end of the buffer.
+
+        Returns the new terminal column of the input cursor.
+        """
+        self.input_cursor = len(self.ord_codes)
+        self.terminal_column = self._get_column_at_cursor()
+        return self.terminal_column
+
+    def move_left(self) -> int:
+        """
+        Move input cursor one character to the left.
+
+        Returns the new terminal column of the input cursor.
+        """
+        if self.input_cursor > 0:
+            move_distance = self._get_column_move_distance_for_cursor_move(-1)
+            self.input_cursor -= 1
+            self.terminal_column -= move_distance
+        return self.terminal_column
+
+    def move_right(self) -> int:
+        """
+        Move the input cursor one character to the right.
+
+        Returns the new terminal column of the input cursor.
+        """
+        if self.input_cursor < len(self.ord_codes):
+            move_distance = self._get_column_move_distance_for_cursor_move(1)
+            self.input_cursor += 1
+            self.terminal_column += move_distance
+        return self.terminal_column
+
+    def _get_column_at_cursor(self) -> int:
+        codes_to_cursor = self.ord_codes[: self.input_cursor]
+        column = self._calculate_column_for_codes(codes_to_cursor)
+        return column
+
+    def _get_column_move_distance_for_cursor_move(self, cursor_move: int) -> int:
+        index_after_move = self.input_cursor + cursor_move
+        codes_after_move = self.ord_codes[:index_after_move]
+        new_column = self._calculate_column_for_codes(codes_after_move)
+        return abs(self.terminal_column - new_column)
+
+    def _calculate_column_for_codes(self, codes: list[int]) -> int:
+        first_user_column = self._first_terminal_column + self.prompt_length
+        terminal_column = first_user_column
+        for ord_code in codes:
+            if ord_code == ORD_TAB:
+                one_based_x = terminal_column - self._first_terminal_column
+                one_based_remainder = one_based_x % self.tab_size
+                to_next_tab_stop = self.tab_size - one_based_remainder
+                terminal_column += to_next_tab_stop
+            else:
+                terminal_column += 1
+        return terminal_column

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -68,6 +68,7 @@ _CONTROL_PATTERN_UPPER_F_KEY = 4      # F5..F12                         : code 0
 
 _PREVIOUS_ORD = _ORD_NUL
 
+
 class InMemoryHistory:
     """An in-memory history of commands, infinite in size."""
 
@@ -219,7 +220,9 @@ def _prompt(message: str, in_stream: BinaryIO, out_stream: BinaryIO, history: In
     return decoded
 
 
-def _process_control_sequence(control_codes, in_ord, control_pattern, key_codes, out_stream):
+def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- need many lines and statements to process control codes
+    control_codes: list[int], in_ord: int, control_pattern: int, key_codes: LineBuffer, out_stream: BinaryIO
+) -> int:
     control_codes.append(in_ord)
     control_command_length = len(control_codes)
     if control_command_length == 2:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -144,10 +144,14 @@ def _console_csi_command(command_sequence_ords: list[int], output: BinaryIO) -> 
     output.write(bytes(full_command))
 
 
-# CSI Ps P  Delete Ps Character(s) (default = 1)
-#   - difficult to track tabs
-# CSI Ps X  Erase Ps Character(s) (default = 1)
+# Room for improvement
+# Delete the columns, do not redraw from the cursor
+# - CSI Ps P  Delete Ps Character(s) (default = 1)
+#   - also need to track tabs
+# - CSI Ps X  Erase Ps Character(s) (default = 1)
 #   - untested
+# Insert empty columns and fill them with new input characters
+# - CSI Ps @  Insert Ps (Blank) Character(s) (default = 1)
 def _redraw_from_column(from_column: int, ords_to_draw: list[int], output: BinaryIO) -> None:
     """Erase the line starting at from_column and redraw ords_to_draw."""
     _set_cursor_column(from_column, output)
@@ -164,7 +168,7 @@ def _redraw_from_column(from_column: int, ords_to_draw: list[int], output: Binar
 # (untested: expecting Linux to send LF)
 def _prompt(message: str, in_stream: BinaryIO, out_stream: BinaryIO, history: InMemoryHistory | None = None) -> str:
     """Use a custom shell processor to prompt the user with message and return the response."""
-    global _PREVIOUS_ORD  # noqa PLW0603 -- need a global to track EOL characters from Windows across calls
+    global _PREVIOUS_ORD  # noqa PLW0603 -- need a global to track EOL characters from Windows across calls in a session
     out_stream.write(message.encode("UTF-8"))
 
     key_codes = LineBuffer(prompt_length=len(message))
@@ -220,7 +224,7 @@ def _prompt(message: str, in_stream: BinaryIO, out_stream: BinaryIO, history: In
     return decoded
 
 
-def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- need many lines and statements to process control codes
+def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- we need many lines and statements to process control codes
     control_codes: list[int], in_ord: int, control_pattern: int, key_codes: LineBuffer, out_stream: BinaryIO
 ) -> int:
     """Track and handle the control codes as they are read."""

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -268,13 +268,13 @@ def _prompt(message="", *, input_=None, output=None, history=None, debug=False):
             # - Delete
             debug(f"** skipping non printable char {in_ord}")
         elif in_ord == ORD_BACKSPACE:
-            deleted_count = key_codes.backspace()
-            if deleted_count:
+            deleted_columns = key_codes.backspace()
+            if deleted_columns:
                 # save cursor column
                 old_column = get_cursor_column(output, input=input_)
                 redraw_input(output, len(message) + 1, key_codes.ord_codes)
                 # restore cursor column
-                set_cursor_column(new_column=old_column-1, output=output)
+                set_cursor_column(new_column=old_column-deleted_columns, output=output)
         else:
             debug(f"** accepted {debug_str(in_ord)}")
             key_codes.accept(in_ord)
@@ -414,16 +414,18 @@ class LineBuffer:
 
     def delete(self):
         if self.index == len(self.ord_codes):
-            deleted_count = 0
+            deleted_columns = 0
         else:
             deleted = self.ord_codes.pop(self.index)
-            deleted_count = self.column - self.get_column()
+            deleted_columns = self.column - self.get_column()
         self.column = self.get_column()
-        return deleted_count
+        return deleted_columns
 
     def backspace(self):
-        if self.move_left():
-            return self.delete()
+        move_distance = self.move_left()
+        if move_distance:
+            deleted_columns = self.delete()
+            return move_distance + deleted_columns
         else:
             return 0
 

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -144,7 +144,7 @@ def _console_csi_command(command_sequence_ords: list[int], output: BinaryIO) -> 
     output.write(bytes(full_command))
 
 
-# Room for improvement
+# Room for improvement -- see GitHub Issue #30
 # Delete the columns, do not redraw from the cursor
 # - CSI Ps P  Delete Ps Character(s) (default = 1)
 #   - also need to track tabs

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -1,0 +1,156 @@
+# Reworked from https://github.com/adafruit/Adafruit_CircuitPython_Prompt_Toolkit
+
+
+KEY_ESCAPE = b"\x1b"
+KEY_CR = b"\x0d"
+KEY_LF = b"\x0a"
+
+KEY_OPEN_BRACKET = b"["
+ORD_OPEN_BRACKET = ord(KEY_OPEN_BRACKET)
+
+KEY_DEL = b"\x7f"
+ORD_DEL = ord(KEY_DEL)
+
+
+_PREVIOUS_ORD = 0
+
+def __unused(*args):
+    pass
+
+
+def is_printable(char_ord):
+    return char_ord > 31 and char_ord < 127
+
+
+def debug_str(in_charbyte):
+    return in_charbyte if is_printable(ord(in_charbyte)) else "?"
+
+
+# plink only sends CR (like classic macOS)
+# miniterm sends CRLF on Windows
+# (untested: expecting Linux to send LF)
+def _prompt(message="", *, input_=None, output=None, history=None, debug=False):
+    global _PREVIOUS_ORD
+    debug = True
+    debug = print if debug else __unused
+    output.write(message.encode("utf-8"))
+    key_codes = []
+    control_codes = []
+    break_loop = False
+    while (not key_codes or _PREVIOUS_ORD not in [ord(KEY_CR), ord(KEY_LF)]) and not break_loop:
+        in_char = input_.read(1)
+        in_ord = in_char[0]
+        debug(f"* received {in_ord:4}d {debug_str(in_char):4} previous {_PREVIOUS_ORD:4}")
+
+        if control_codes:
+            debug(f"** entering control char sequence {control_codes}")
+            control_codes.append(in_ord)
+            if len(control_codes) == 2:
+                if in_ord != ORD_OPEN_BRACKET:
+                    debug(f"*** exiting control char sequence unsupported control code {in_ord:4}")
+                    control_codes.clear()
+            else:
+                if (ord("0") <= in_ord <= ord("9")):
+                    debug(f"*** skipping control char sequence non-numeral control code {in_ord:4} {debug_str(in_char):4}")
+                else:
+                    debug(f"*** processing control code {in_ord:4}")
+                    control_codes.clear()
+            continue
+        if in_char in [KEY_ESCAPE]:
+            debug("** detected control char sequence")
+            control_codes.append(in_ord)
+            continue
+        if in_char == KEY_LF and _PREVIOUS_ORD == ord(KEY_CR):
+            # Throw away the line feed from Windows
+            debug("** completed windows EOL")
+            continue
+        if in_char in [KEY_CR, KEY_LF]:
+            # Do not capture EOL characters
+            # Filter for more
+            # - F-keys start with \x01 and are either 2 more chars like 'bOP' 5 more chars like 'b[15~'
+            # - Other non-printables
+            # But allow
+            # - Backspace \x08
+            # - TAB \x09
+            # - Delete
+            debug("** skipped EOL char")
+            pass
+        else:
+            debug(f"** accepted {in_char}")
+            key_codes.append(in_ord)
+
+        if in_ord == ORD_DEL:
+            key_codes.pop()  # Remove the DEL char
+            key_codes.pop()  # Remove the preceding char
+            output.write(b"\b\x1b[K")  # Update the line
+        elif in_char in [KEY_CR, KEY_LF]:
+            # Do not echo EOL characters back to the user
+            debug("** matched loop exit")
+            break_loop = True
+        else:
+            output.write(in_char)
+
+        _PREVIOUS_ORD = in_ord
+        debug(f"\n** loop conditions key_codes: {key_codes} previous_ord: {_PREVIOUS_ORD} break: {break_loop}")
+    output.write(b"\n")
+    debug("encoded", key_codes)
+
+    decoded = bytes(key_codes).decode("utf-8")
+    return decoded
+
+
+def prompt(message="", *, input=None, output=None):
+    """Prompt the user for input over the ``input`` stream with the given
+    ``message`` output on ``output``. Handles control characters for value editing."""
+    # "input" and "output" are only on PromptSession in upstream "prompt_toolkit" but we use it for
+    # prompts without history.
+    # pylint: disable=redefined-builtin
+    return _prompt(message, input_=input, output=output)
+
+
+class PromptSession:
+    """Session for multiple prompts. Stores common arguments to `prompt()` and
+    history of commands for user selection."""
+
+    def __init__(self, message="", *, input=None, output=None, history=None):
+        # "input" and "output" are names used in upstream "prompt_toolkit" so we
+        # use them too.
+        # pylint: disable=redefined-builtin
+        self.message = message
+        self._input = input
+        self._output = output
+
+        self.history = history if history else InMemoryHistory()
+
+    def prompt(self, message=None) -> str:
+        """Prompt the user for input over the session's ``input`` with the given
+        message or the default message."""
+        message = message if message else self.message
+
+        decoded = _prompt(
+            message, input_=self._input, output=self._output, history=self.history
+        )
+
+        return decoded
+
+
+# SPDX-FileCopyrightText: Copyright (c) 2023 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""Various ways of storing command history."""
+
+
+class InMemoryHistory:
+    """Simple in-memory history of commands. It is infinite size."""
+
+    def __init__(self):
+        self._history = []
+
+    def append_string(self, string: str) -> None:
+        """Append a string to the history of commands."""
+        self._history.append(string)
+
+    def get_strings(self) -> list[str]:
+        """List of all past strings. Oldest first."""
+        return self._history

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -1,4 +1,11 @@
+"""Custom terminal prompt for interactive shells."""
+
 # Reworked from https://github.com/adafruit/Adafruit_CircuitPython_Prompt_Toolkit
+
+try:  # noqa: SIM105 -- contextlib is not available for CircuitPython
+    from typing import BinaryIO, Callable
+except ImportError:
+    pass
 
 ORD_NUL = 0x00
 ORD_FKEY_START = 0x01
@@ -50,12 +57,13 @@ NOOP_ORDS = [
     0x1F,
 ]
 
+# fmt: off
 CONTROL_PATTERN_NONE = 0
 CONTROL_PATTERN_MOVE_CURSOR_KEY = 1  # up, down, right, left, end, home: code 0x1B then '['  then the single-ord command: one of [ABCDFH]
 CONTROL_PATTERN_EDITOR_KEY = 2       # Ins Del PgUp PgDown             : code 0x1B then '['  then the single-ord command: one of [2356]                 then the close '~'
 CONTROL_PATTERN_LOWER_F_KEY = 3      # F1..F4                          : code 0x01 then 'bO' then the single-ord command: one of [PQRS]
 CONTROL_PATTERN_UPPER_F_KEY = 4      # F5..F12                         : code 0x01 then 'b[' then the   dual-ord command:        [1][5789] or [2][0123] then the close '~'
-
+# fmt: on
 
 _PREVIOUS_ORD = ORD_NUL
 
@@ -71,78 +79,103 @@ _PRINTABLE_FOR_NONPRINTABLE = {
     ORD_DEL: "DEL",
 }
 
-def __unused(*args):
-    pass
+
+class InMemoryHistory:
+    """An in-memory history of commands, infinite in size."""
+
+    def __init__(self) -> None:
+        """Create a new in-memory history buffer."""
+        self._history = []
+
+    def append_string(self, string: str) -> None:
+        """Append a string to the history of commands."""
+        self._history.append(string)
+
+    def get_strings(self) -> list[str]:
+        """List of all past strings. Oldest first."""
+        return self._history
 
 
-def is_printable(char_ord):
-    return char_ord > 31 and char_ord < 127
+def is_printable(char_ord: int) -> bool:
+    """Return true if the specified ordinal is printable in a terminal."""
+    # https://ss64.com/ascii.html
+    return char_ord > 31 and char_ord < 127  # noqa: PLR2004 -- ordinals /are/ magic numbers
 
 
-def debug_str(in_ordinal):
+def debug_str(in_ordinal: int) -> str:
+    """Return a printable substitute for a non-printable ordinal."""
     return chr(in_ordinal) if is_printable(in_ordinal) else _PRINTABLE_FOR_NONPRINTABLE.get(in_ordinal, "?")
 
 
-def console_query(query_sequence_ords, output, input, stop_ord):
-    output.write(bytes(query_sequence_ords))
+def console_query(
+    query_sequence_ords: list[int], out_stream: BinaryIO, in_stream: BinaryIO, stop_ord: int
+) -> list[int]:
+    """Send the query_sequence_ords to the remote console and return its response."""
+    out_stream.write(bytes(query_sequence_ords))
     in_ord = ORD_NUL
     response_ords = []
     while in_ord != stop_ord:
-        in_char = input.read(1)
+        in_char = in_stream.read(1)
         in_ord = ord(in_char)
         response_ords.append(in_ord)
     return response_ords
 
 
-def console_esc_ob_command(command_sequence_ords, output):
+def get_cursor_column(output: BinaryIO, in_stream: BinaryIO) -> int:
+    """Get the cursor column from the remote console."""
+    cursor_position_codes = console_query(
+        query_sequence_ords=[ORD_ESC, ORD_OPEN_BRACKET, ord("6"), ord("n")],
+        out_stream=output,
+        in_stream=in_stream,
+        stop_ord=ord("R"),
+    )
+    # Full response has format ESC[#;#R
+    clipped = cursor_position_codes[2:-1]
+    semicolon_index = clipped.index(ORD_SEMICOLON)
+    column_ords = clipped[semicolon_index + 1 :]
+    return int(bytes(column_ords))
+
+
+def set_cursor_column(new_column: int, output: BinaryIO) -> None:
+    """Set the cursor column in the remote console."""
+    # ESC[##G to set cursor column
+    column_number = [ord(x) for x in list(str(new_column))]
+    column_number.append(ord("G"))
+    console_csi_command(column_number, output)
+
+
+def hide_cursor(output: BinaryIO) -> None:
+    """Hide the cursor in the remote console."""
+    # ESC[?25l to make cursor invisible
+    hide_cursor = [ord(x) for x in list("?25l")]
+    console_csi_command(hide_cursor, output)
+
+
+def show_cursor(output: BinaryIO) -> None:
+    """Show the cursor in the remote console."""
+    # ESC[?25h to make cursor visible
+    show_cursor = [ord(x) for x in list("?25h")]
+    console_csi_command(show_cursor, output)
+
+
+def console_csi_command(command_sequence_ords: list[int], output: BinaryIO) -> None:
+    """Send a command prefixed with the control sequence introducer 'ESC ['."""
     full_command = [ORD_ESC, ORD_OPEN_BRACKET]
     full_command.extend(command_sequence_ords)
     output.write(bytes(full_command))
 
 
-def get_cursor_column(output, input):
-    cursor_position_codes = console_query(
-        query_sequence_ords=[ORD_ESC, ORD_OPEN_BRACKET, ord("6"), ord("n")],
-        output=output,
-        input=input,
-        stop_ord=ord("R")
-    )
-    # Full response has format ESC[#;#R
-    clipped = cursor_position_codes[2:-1]
-    semicolon_index = clipped.index(ORD_SEMICOLON)
-    line_ords = clipped[:semicolon_index]
-    column_ords = clipped[semicolon_index+1:]
-    return int(bytes(column_ords))
-
-
-def set_cursor_column(new_column, output):
-    column_number = [ord(x) for x in list(str(new_column))]
-    column_number.append(ord("G"))
-    console_esc_ob_command(column_number, output)
-
-
-def hide_cursor(output):
-    # ESC[?25l to make cursor invisible
-    hide_cursor = [ord("?"), ord("2"), ord("5"), ord("l")]
-    console_esc_ob_command(hide_cursor, output)
-
-
-def show_cursor(output):
-    # ESC[?25h to make cursor visible
-    hide_cursor = [ord("?"), ord("2"), ord("5"), ord("h")]
-    console_esc_ob_command(hide_cursor, output)
-
-
-#CSI Ps P  Delete Ps Character(s) (default = 1)
-## - difficult to track tabs
-#CSI Ps X  Erase Ps Character(s) (default = 1)
-
-def redraw_from_column(output, from_column, ords_to_draw):
+# CSI Ps P  Delete Ps Character(s) (default = 1)
+#   - difficult to track tabs
+# CSI Ps X  Erase Ps Character(s) (default = 1)
+#   - untested
+def redraw_from_column(from_column: int, ords_to_draw: list[int], output: BinaryIO) -> None:
+    """Erase the line starting at from_column and redraw ords_to_draw."""
     set_cursor_column(from_column, output)
 
     # ESC[0K to erase from cursor to end of line
-    erase_to_eol = [ord("0"), ord("K")]
-    console_esc_ob_command(erase_to_eol, output)
+    erase_to_eol = [ord(x) for x in list("0K")]
+    console_csi_command(erase_to_eol, output)
 
     output.write(bytes(ords_to_draw))
 
@@ -152,31 +185,29 @@ def redraw_from_column(output, from_column, ords_to_draw):
 ##            does     autocomplete on globals() with tab (not configurable)
 ##            does     support UTF-8 characters
 ##            does not support the F-keys but echoes the printable control codes and homes the cursor
-def _prompt2(message="", *, input_=None, output=None, history=None, debug=False):
-    from_remote = input("p2]")
+def _prompt2(message: str = "") -> str:
+    """Use the built-in 'input' function to prompt the user with message and return the response."""
+    from_remote = input(message)
     return from_remote
 
 
-def traced(traced_function, trace_list):
-    # AttributeError: can't set attribute 'write'
-    def with_tracing(*args, **kwargs):
+# AttributeError: can't set attribute 'write'
+def traced(traced_function: Callable, trace_list: list[str]) -> Callable:
+    """When traced_function is called, add a message containing the parameters to trace_list."""
+
+    def with_tracing(*args, **kwargs) -> Callable:  # noqa: ANN002 ANN003 -- wrapping an unknown function signature
         trace_list.append(f"{args} {kwargs}")
         return traced_function(*args, **kwargs)
+
     return with_tracing
 
 
 # plink only sends CR (like classic macOS)
 # miniterm sends CRLF on Windows
 # (untested: expecting Linux to send LF)
-# - add tests on codes
-#   - assert on the bytes received and bytes sent
-# - use other vt commands to manipulate the cursor and text?
-# - use regex to help?
-def _prompt(message, in_stream, out_stream, history=None):
-
-    trace_record = __unused
-
-    global _PREVIOUS_ORD
+def _prompt(message: str, in_stream: BinaryIO, out_stream: BinaryIO, history: InMemoryHistory | None = None) -> str:  # noqa: PLR0912 PLR0915 -- need many lines and statements to process control codes
+    """Use a custom shell processor to prompt the user with message and return the response."""
+    global _PREVIOUS_ORD  # noqa PLW0603 -- need a global to track EOL characters from Windows across calls
     out_stream.write(message.encode("UTF-8"))
 
     key_codes = LineBuffer(prompt_length=len(message))
@@ -187,340 +218,352 @@ def _prompt(message, in_stream, out_stream, history=None):
     while (not key_codes.has_bytes() or _PREVIOUS_ORD not in [ORD_CR, ORD_LF]) and not break_loop:
         in_bytes = in_stream.read(1)
         in_ord = in_bytes[0]
-        trace_record(f"* received {in_ord:4}d {debug_str(in_ord):4} previous {debug_str(_PREVIOUS_ORD):4}")
 
         if control_codes:
             control_codes.append(in_ord)
             control_command_length = len(control_codes)
-            trace_record(f"** entering control char sequence {control_codes}")
-            if control_command_length == 2:
+            if control_command_length == 2:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning
                 if control_codes[0] == ORD_ESC and in_ord == ORD_OPEN_BRACKET:
-                    # begin escape control sequence
-                    trace_record(f"** detected ESC control char sequence {control_codes}")
-                    control_pattern = CONTROL_PATTERN_MOVE_CURSOR_KEY  # Assume until further reads show otherwise
+                    # Begin escape control sequence, assume cursor move until further reads show otherwise
+                    control_pattern = CONTROL_PATTERN_MOVE_CURSOR_KEY
                 elif control_codes[0] == ORD_FKEY_START and in_ord == ORD_LOWER_B:
-                    # begin f-key control sequence
-                    trace_record(f"** detected F-key control char sequence {control_codes}")
-                    control_pattern = CONTROL_PATTERN_LOWER_F_KEY  # Assume until further reads show otherwise
+                    # Begin F-key control sequence, assume lower F-key until further reads show otherwise
+                    control_pattern = CONTROL_PATTERN_LOWER_F_KEY
                 else:
-                    trace_record(f"*** exiting control char sequence unsupported control code {debug_str(in_ord):4}")
+                    # No handlers for other command sequences
                     control_codes.clear()
-            elif control_command_length == 3:
+            elif control_command_length == 3:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning
                 if control_pattern == CONTROL_PATTERN_MOVE_CURSOR_KEY:
-                    if (ord("0") <= in_ord <= ord("9")):
+                    if ord("0") <= in_ord <= ord("9"):
                         # We read more and learned we're reading an editor command
                         control_pattern = CONTROL_PATTERN_EDITOR_KEY
-                        trace_record(f"*** processing editor control code {debug_str(in_ord):4}")
                     else:
-                        move_cursor_command = []
+                        # We're reading a letter or symbol command ESC[*
+                        old_column = key_codes.get_terminal_column()
+                        new_column = old_column
                         if in_ord == ord("C"):
-                            columns_moved = key_codes.move_right()
-                            if columns_moved:
-                                as_ords = [ord(x) for x in list(str(columns_moved))]
-                                move_cursor_command.extend(as_ords)
+                            new_column = key_codes.move_right()
                         elif in_ord == ord("D"):
-                            columns_moved = key_codes.move_left()
-                            if columns_moved:
-                                as_ords = [ord(x) for x in list(str(columns_moved))]
-                                move_cursor_command.extend(as_ords)
+                            new_column = key_codes.move_left()
                         elif in_ord == ord("F"):
-                            new_cursor = key_codes.move_end()
-                            set_cursor_column(new_column=new_cursor + 1, output=out_stream)
+                            new_column = key_codes.move_end()
                         elif in_ord == ord("H"):
-                            key_codes.move_home()
-                            set_cursor_column(new_column=len(message) + 1, output=out_stream)
-                        if move_cursor_command:
-                            move_cursor_command.append(in_ord)
-                            console_esc_ob_command(move_cursor_command, out_stream)
-                        trace_record(f"*** completed move-cursor control code {debug_str(in_ord):4}")
+                            new_column = key_codes.move_home()
+
+                        if new_column != old_column:
+                            set_cursor_column(new_column, out_stream)
+
+                        # Handling CSI control sequence complete
                         control_pattern = CONTROL_PATTERN_NONE
                         control_codes.clear()
                 elif control_pattern == CONTROL_PATTERN_LOWER_F_KEY:
                     if in_ord == ORD_OPEN_BRACKET:
                         # We read more and learned we're reading an upper F-key command
                         control_pattern = CONTROL_PATTERN_UPPER_F_KEY
-                        trace_record(f"** detected upper F-key control char sequence {control_codes}")
                     else:
-                        trace_record(f"*** processing lower F-key control code {debug_str(in_ord):4}")
-            elif control_command_length == 4:
+                        # No handlers for lower F-key codes
+                        pass
+            elif control_command_length == 4:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning
                 if control_pattern == CONTROL_PATTERN_EDITOR_KEY:
                     if in_ord == ORD_TILDE:
-                        trace_record(f"*** completed processing editor control code {debug_str(in_ord):4}")
                         if control_codes[2:-1] == [ord("3")]:
-                            # Delete
-                            deleted_columns = key_codes.delete()
-                            old_column = get_cursor_column(out_stream, input=in_stream)
-                            redraw_input(out_stream, len(message) + 1, key_codes.ord_codes)
-                            set_cursor_column(new_column=old_column, output=out_stream)
+                            # Delete is ESC[3~
+                            cursor_column, codes_to_redraw = key_codes.delete()
+                            hide_cursor(out_stream)
+                            redraw_from_column(cursor_column, codes_to_redraw, out_stream)
+                            set_cursor_column(cursor_column, out_stream)
+                            show_cursor(out_stream)
+                        # Handling complete -- '~' terminated command
                         control_pattern = CONTROL_PATTERN_NONE
                         control_codes.clear()
                 elif control_pattern == CONTROL_PATTERN_LOWER_F_KEY:
-                    trace_record(f"*** completed processing lower F-key control code {debug_str(in_ord):4}")
+                    # Handling lower F-key control code complete -- fixed length command
                     control_pattern = CONTROL_PATTERN_NONE
                     control_codes.clear()
-            else:
+            else:  # noqa: PLR5501 -- this level of if-else is for branching based on the command sequence length
                 if in_ord == ORD_TILDE:
-                    trace_record(f"*** completed processing upper F-key control code {debug_str(in_ord):4}")
+                    # Handling upper F-key control code complete -- '~' terminated command
                     control_pattern = CONTROL_PATTERN_NONE
                     control_codes.clear()
                 else:
-                    trace_record(f"*** processing upper F-key control code {debug_str(in_ord):4}")
+                    # No handlers for upper F-key codes
+                    pass
+            # Keep reading more control codes
             continue
 
         if in_ord in [ORD_ESC, ORD_FKEY_START]:
-            trace_record("** detected control char sequence")
+            # Begin a control sequence
             control_codes.append(in_ord)
             continue
 
         if in_ord == ORD_LF and _PREVIOUS_ORD == ORD_CR:
             # Throw away the line feed from Windows
-            trace_record("** completed windows EOL")
             continue
 
         if in_ord in [ORD_CR, ORD_LF]:
-            # Do not capture EOL characters
-            trace_record("** matched loop exit")
+            # Do not capture or handle EOL characters
             break_loop = True
         elif in_ord in NOOP_ORDS:
-            trace_record(f"** skipping non printable char {in_ord}")
+            # No handlers for these
+            pass
         elif in_ord == ORD_BACKSPACE:
-            deleted_columns = key_codes.backspace()
-            if deleted_columns:
-                # save cursor column
-                old_column = get_cursor_column(out_stream, input=in_stream)
-                redraw_input(out_stream, len(message) + 1, key_codes.ord_codes)
-                # restore cursor column
-                set_cursor_column(new_column=old_column-deleted_columns, output=out_stream)
+            # Handle backspace
+            cursor_column, codes_to_redraw = key_codes.backspace()
+            hide_cursor(out_stream)
+            redraw_from_column(cursor_column, codes_to_redraw, out_stream)
+            set_cursor_column(cursor_column, out_stream)
+            show_cursor(out_stream)
         else:
-            trace_record(f"** accepted {debug_str(in_ord)}")
-            new_column = key_codes.accept(in_ord)
-            redraw_input(out_stream, len(message) + 1, key_codes.ord_codes)
-            set_cursor_column(new_column=new_column + 1, output=out_stream)
+            # Accept the user's input character
+            old_column = key_codes.get_terminal_column()
+            new_column, codes_to_redraw = key_codes.accept(in_ord)
+            hide_cursor(out_stream)
+            redraw_from_column(old_column, codes_to_redraw, out_stream)
+            set_cursor_column(new_column, out_stream)
+            show_cursor(out_stream)
 
         _PREVIOUS_ORD = in_ord
-        trace_record(f"** loop conditions key_codes: {key_codes.ord_codes} previous_char: {debug_str(_PREVIOUS_ORD)} break: {break_loop}")
 
     out_stream.write(b"\n")
-    trace_record(f"encoded {key_codes.get_decoded_bytes()}")
 
     decoded = key_codes.get_decoded_bytes()
     return decoded
 
 
-def prompt(message="", *, input=None, output=None):
-    """Prompt the user for input over the ``input`` stream with the given
-    ``message`` output on ``output``. Handles control characters for value editing."""
-    # "input" and "output" are only on PromptSession in upstream "prompt_toolkit" but we use it for
-    # prompts without history.
-    # pylint: disable=redefined-builtin
-    return _prompt(message, in_stream=input, out_stream=output)
+def prompt(message: str = "", *, in_stream: BinaryIO, out_stream: BinaryIO) -> str:
+    """Prompt the user for input with the given message."""
+    return _prompt(message, in_stream, out_stream)
 
 
 class TracedReader:
-    """input_stream must support a function with signature 'read(int) -> str'"""
-    def __init__(self, input_stream, shared_tracelog, log_prefix=None):
+    """A stream reader that logs bytes read from the stream."""
+
+    def __init__(self, input_stream: BinaryIO, shared_tracelog: list[str], log_prefix: str | None = None) -> None:
+        """
+        Create a TracedReader that logs all reads from input_stream into shared_tracelog.
+
+        input_stream must support a function with signature 'read(int) -> bytes'.
+        """
         self._input_stream = input_stream
         self._shared_tracelog = shared_tracelog
         self._log_prefix = log_prefix if log_prefix is not None else type(self)
         self._trace(f"tracing input from {type(input_stream)}")
 
-    def _trace(self, message):
-        self._shared_tracelog.append(f"{self._log_prefix}{message}")
-
-    def read(self, byte_count):
+    def read(self, byte_count: int) -> bytes:
+        """Read from the input_stream and log it."""
         input_chars = self._input_stream.read(byte_count)
-        ordinals_read = input_chars  # [f"0x{code:02x}" for code in list(input_chars)]
-        self._trace(f" in   {ordinals_read}")
+        self._trace(f" in   {input_chars}")
         return input_chars
+
+    def _trace(self, message: str) -> None:
+        self._shared_tracelog.append(f"{self._log_prefix}{message}")
 
 
 class TracedWriter:
-    """output_stream must support a function with signature 'write(str) -> None'"""
-    def __init__(self, output_stream, shared_tracelog, log_prefix=None):
+    """A stream writer that logs bytes written to the stream."""
+
+    def __init__(self, output_stream: BinaryIO, shared_tracelog: list[str], log_prefix: str | None = None) -> None:
+        """
+        Create a TracedWriter that logs all writes to output_stream into shared_tracelog.
+
+        output_stream must support a function with signature 'write(bytes) -> None'.
+        """
         self._output_stream = output_stream
         self._shared_tracelog = shared_tracelog
         self._log_prefix = log_prefix if log_prefix is not None else type(self)
         self._trace(f"tracing output from {type(output_stream)}")
 
-    def _trace(self, message):
-        self._shared_tracelog.append(f"{self._log_prefix}{message}")
-
-    def write(self, encoded_string):
-        ordinals_sent = encoded_string  # [f"0x{code:02x}" for code in list(encoded_string)]
-        self._trace(f"out > {ordinals_sent}")
+    def write(self, encoded_string: bytes) -> None:
+        """Read to the output_stream and log it."""
+        self._trace(f"out > {encoded_string}")
         self._output_stream.write(encoded_string)
+
+    def _trace(self, message: str) -> None:
+        self._shared_tracelog.append(f"{self._log_prefix}{message}")
 
 
 class IOTracer:
-    def __init__(self, input_stream, output_stream):
+    """An IO stream tracer that logs bytes read and written to the streams."""
+
+    def __init__(self, input_stream: BinaryIO, output_stream: BinaryIO) -> None:
+        """Create an IOTracer that logs all IO with input_stream and output_stream."""
         self._shared_tracelog = []
         self._traced_input = TracedReader(input_stream, self._shared_tracelog, log_prefix="")
         self._traced_output = TracedWriter(output_stream, self._shared_tracelog, log_prefix="")
 
     @property
-    def input_stream(self):
+    def input_stream(self) -> TracedReader:
+        """Return the TracedReader used by the IOTracer."""
         return self._traced_input
 
     @property
-    def output_stream(self):
+    def output_stream(self) -> TracedWriter:
+        """Return the TracedWriter used by the IOTracer."""
         return self._traced_output
 
     @property
-    def traced_io_log(self):
+    def traced_io_log(self) -> list[str]:
+        """Return a copy of the logged IO traces from the streams."""
         return self._shared_tracelog.copy()
 
-    def clear_log(self):
+    def clear_log(self) -> None:
+        """Clear the trace log."""
         self._shared_tracelog.clear()
 
 
 class PromptSession:
-    """Session for multiple prompts. Stores common arguments to `prompt()` and
-    history of commands for user selection."""
+    """A shell-like session for multiple interactive prompts that supports line editing and command history."""
 
-    def __init__(self, message="", *, input=None, output=None, history=None):
-        # "input" and "output" are names used in upstream "prompt_toolkit" so we
-        # use them too.
-        # pylint: disable=redefined-builtin
-        self.message = message
-        self._input = input
-        self._output = output
+    def __init__(
+        self,
+        in_stream: BinaryIO,
+        out_stream: BinaryIO,
+        default_prompt: str = "",
+        history: InMemoryHistory | None = None,
+    ) -> None:
+        """Create a PromptSession using in_stream and out_stream for IO, with an optional default_prompt and command history buffer."""
+        self.default_prompt = default_prompt
+        self.in_stream = in_stream
+        self.out_stream = out_stream
         self.history = history if history else InMemoryHistory()
 
-    def prompt(self, message=None) -> str:
-        """Prompt the user for input over the session's ``input`` with the given
-        message or the default message."""
-        message = message if message else self.message
+    def prompt(self, message: str | None = None) -> str:
+        """Prompt the user for input with the given message or the default message."""
+        message = message if message else self.default_prompt
 
-        decoded = _prompt(
-            message, in_stream=self._input, out_stream=self._output, history=self.history
-        )
-
-        # decoded = _prompt2(
-        #     message, input_=self._input, output=self._output, history=self.history
-        # )
+        decoded = _prompt(message, in_stream=self.in_stream, out_stream=self.out_stream, history=self.history)
 
         return decoded
 
 
 class LineBuffer:
-    def __init__(self, prompt_length, tab_size=8):
-        self.ord_codes = []
-        self.index = 0
-        self.prompt_length = prompt_length  # assumes that the prompt doesnt have a tab character :(
-        self.tab_size = tab_size
-        self._first_terminal_column = 1
-        self.column = self._get_column()
+    """A user input buffer that supports tabs, moving the cursor, deleting, and backspacing."""
 
-    def has_bytes(self):
+    def __init__(self, prompt_length: int, tab_size: int = 8) -> None:
+        """Create a new LineBuffer for interactive user input."""
+        self._first_terminal_column = 1
+        self.prompt_length = prompt_length
+        self.tab_size = tab_size
+        self.ord_codes = []
+        self.input_cursor = 0
+        self.terminal_column = self._get_column_at_cursor()
+
+    def has_bytes(self) -> bool:
+        """Return whether the buffer has contents."""
         return len(self.ord_codes) > 0
 
-    def get_decoded_bytes(self):
+    def get_decoded_bytes(self) -> str:
+        """Get the buffer as a UTF-8 string."""
         return bytes(self.ord_codes).decode("UTF-8")
 
-    def get_cursor_column(self):
-        return self._get_column()
+    def get_terminal_column(self) -> int:
+        """Return the terminal column of the input cursor."""
+        return self.terminal_column
 
-    def _peek_next(self):
-        if self.index == len(self.ord_codes):
-            return None
-        else:
-            return self.ord_codes[self.index]
+    def accept(self, ord_code: int) -> tuple[int, list[int]]:
+        """
+        Insert a new ordinate at the input cursor.
 
-    def _peek_previous(self):
-        if self.index == 0:
-            return None
-        else:
-            return self.ord_codes[self.index - 1]
+        Returns a tuple of the new terminal column and a slice of the
+        input buffer from the new ordinate to the end of the buffer.
+        """
+        self.ord_codes.insert(self.input_cursor, ord_code)
+        code_with_remaining_line = self.ord_codes[self.input_cursor :]
+        self.input_cursor += 1
+        self.terminal_column = self._get_column_at_cursor()
+        return self.terminal_column, code_with_remaining_line
 
-    def accept(self, ord_code):
-        self.ord_codes.insert(self.index, ord_code)
-        self.index += 1
-        self.column = self._get_column()
-        return self.column
+    def delete(self) -> tuple[int, list[int]]:
+        """
+        Delete the ordinate after the input cursor.
 
-    def _move_distance(self, direction):
-        first_user_column = self._first_terminal_column + self.prompt_length
-        column = first_user_column
-        for ord in self.ord_codes[:self.index+direction]:
-            if ord == ORD_TAB:
-                tab_stops, remaining_columns = divmod(column, self.tab_size)
-                to_next_tab_stop = self.tab_size - remaining_columns
-                column += to_next_tab_stop
-            else:
-                column += 1
-        return abs(self.column - column)
+        Returns a tuple of the new terminal column and a slice of the
+        input buffer from the cursor to the end of the buffer.
+        """
+        if self.input_cursor < len(self.ord_codes):
+            _ = self.ord_codes.pop(self.input_cursor)
+            self.terminal_column = self._get_column_at_cursor()
+        remaining_line = self.ord_codes[self.input_cursor :]
+        return self.terminal_column, remaining_line
 
-    def move_right(self):
-        # Maybe always return self.column
-        move_distance = 0
-        next_ord = self._peek_next()
-        if next_ord:
-            move_distance = self._move_distance(direction=1)
-            self.index += 1
-            self.column += move_distance
-        return move_distance
+    def backspace(self) -> tuple[int, list[int]]:
+        """
+        Delete the ordinate before the input cursor.
 
-    def move_left(self):
-        # Maybe always return self.column
-        move_distance = 0
-        previous_ord = self._peek_previous()
-        if previous_ord:
-            move_distance = self._move_distance(direction=-1)
-            self.index -= 1
-            self.column -= move_distance
-        return move_distance
+        Returns a tuple of the new terminal column and a slice of the
+        input buffer from the cursor to the end of the buffer.
+        """
+        old_column = self.terminal_column
+        new_column = self.move_left()
+        if new_column != old_column:
+            self.delete()
+        remaining_line = self.ord_codes[self.input_cursor :]
+        return new_column, remaining_line
 
-    def move_home(self):
-        while self.move_left():
-            pass
-        return self.column
+    def move_home(self) -> int:
+        """
+        Move the input cursor to the beginning of the buffer.
 
-    def move_end(self):
-        while self.move_right():
-            pass
-        return self.column
+        Returns the new terminal column of the input cursor.
+        """
+        self.input_cursor = 0
+        self.terminal_column = self._get_column_at_cursor()
+        return self.terminal_column
 
-    def _get_column(self):
-        first_user_column = self._first_terminal_column + self.prompt_length
-        column = first_user_column
-        for ord in self.ord_codes[:self.index]:
-            if ord == ORD_TAB:
-                corrected_x = column - self._first_terminal_column
-                one_based_quotient, one_based_remainder = divmod(corrected_x, self.tab_size)
-                to_next_tab_stop = self.tab_size - one_based_remainder
-                column += to_next_tab_stop
-            else:
-                column += 1
+    def move_end(self) -> int:
+        """
+        Move the input cursor to the end of the buffer.
+
+        Returns the new terminal column of the input cursor.
+        """
+        self.input_cursor = len(self.ord_codes)
+        self.terminal_column = self._get_column_at_cursor()
+        return self.terminal_column
+
+    def move_left(self) -> int:
+        """
+        Move input cursor one character to the left.
+
+        Returns the new terminal column of the input cursor.
+        """
+        if self.input_cursor > 0:
+            move_distance = self._get_column_move_distance_for_cursor_move(-1)
+            self.input_cursor -= 1
+            self.terminal_column -= move_distance
+        return self.terminal_column
+
+    def move_right(self) -> int:
+        """
+        Move the input cursor one character to the right.
+
+        Returns the new terminal column of the input cursor.
+        """
+        if self.input_cursor < len(self.ord_codes):
+            move_distance = self._get_column_move_distance_for_cursor_move(1)
+            self.input_cursor += 1
+            self.terminal_column += move_distance
+        return self.terminal_column
+
+    def _get_column_at_cursor(self) -> int:
+        codes_to_cursor = self.ord_codes[: self.input_cursor]
+        column = self._calculate_column_for_codes(codes_to_cursor)
         return column
 
-    def delete(self):
-        if self.index == len(self.ord_codes):
-            deleted_columns = 0
-        else:
-            deleted = self.ord_codes.pop(self.index)
-            deleted_columns = self.column - self._get_column()
-        self.column = self._get_column()
-        return deleted_columns
+    def _get_column_move_distance_for_cursor_move(self, cursor_move: int) -> int:
+        index_after_move = self.input_cursor + cursor_move
+        codes_after_move = self.ord_codes[:index_after_move]
+        new_column = self._calculate_column_for_codes(codes_after_move)
+        return abs(self.terminal_column - new_column)
 
-    def backspace(self):
-        move_distance = self.move_left()
-        if move_distance:
-            deleted_columns = self.delete()
-            return move_distance + deleted_columns
-        else:
-            return 0
-
-
-class InMemoryHistory:
-    """Simple in-memory history of commands. It is infinite size."""
-
-    def __init__(self):
-        self._history = []
-
-    def append_string(self, string: str) -> None:
-        """Append a string to the history of commands."""
-        self._history.append(string)
-
-    def get_strings(self) -> list[str]:
-        """List of all past strings. Oldest first."""
-        return self._history
+    def _calculate_column_for_codes(self, codes: list[int]) -> int:
+        first_user_column = self._first_terminal_column + self.prompt_length
+        terminal_column = first_user_column
+        for ord_code in codes:
+            if ord_code == ORD_TAB:
+                one_based_x = terminal_column - self._first_terminal_column
+                one_based_remainder = one_based_x % self.tab_size
+                to_next_tab_stop = self.tab_size - one_based_remainder
+                terminal_column += to_next_tab_stop
+            else:
+                terminal_column += 1
+        return terminal_column

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -223,6 +223,7 @@ def _prompt(message: str, in_stream: BinaryIO, out_stream: BinaryIO, history: In
 def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- need many lines and statements to process control codes
     control_codes: list[int], in_ord: int, control_pattern: int, key_codes: LineBuffer, out_stream: BinaryIO
 ) -> int:
+    """Track and handle the control codes as they are read."""
     control_codes.append(in_ord)
     control_command_length = len(control_codes)
     if control_command_length == 2:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning

--- a/src/qtpy_sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_sensor_node/snsr/pysh/py_shell.py
@@ -1,18 +1,73 @@
 # Reworked from https://github.com/adafruit/Adafruit_CircuitPython_Prompt_Toolkit
 
+ORD_NUL = 0x00
+ORD_FKEY_START = 0x01
+ORD_BACKSPACE = 0x08
+ORD_TAB = 0x09
+ORD_LF = 0x0A
+ORD_CR = 0x0D
+ORD_EOF = 0x1A
+ORD_ESC = 0x1B
+ORD_OPEN_BRACKET = 0x5B
+ORD_LOWER_B = 0x62
+ORD_TILDE = 0x7E
+ORD_DEL = 0x7F
 
-KEY_ESCAPE = b"\x1b"
-KEY_CR = b"\x0d"
-KEY_LF = b"\x0a"
+NOOP_ORDS = [
+    # 0x00
+    # 0x01
+    0x02,
+    0x03,
+    0x04,
+    0x05,
+    0x06,
+    0x07,
+    # 0x08
+    # 0x09
+    # 0x0A
+    0x0B,
+    0x0C,
+    # 0x0D
+    0x0E,
+    0x0F,
+    0x10,
+    0x11,
+    0x12,
+    0x13,
+    0x14,
+    0x15,
+    0x16,
+    0x17,
+    0x18,
+    0x19,
+    # 0x1A
+    # 0x1B
+    0x1C,
+    0x1D,
+    0x1E,
+    0x1F,
+]
 
-KEY_OPEN_BRACKET = b"["
-ORD_OPEN_BRACKET = ord(KEY_OPEN_BRACKET)
+CONTROL_PATTERN_NONE = 0
+CONTROL_PATTERN_MOVE_CURSOR_KEY = 1  # up, down, right, left, end, home: code 0x1B then '['  then the single-ord command: one of [ABCDFH]
+CONTROL_PATTERN_EDITOR_KEY = 2       # Ins Del PgUp PgDown             : code 0x1B then '['  then the single-ord command: one of [2356]                 then the close '~'
+CONTROL_PATTERN_LOWER_F_KEY = 3      # F1..F4                          : code 0x01 then 'bO' then the single-ord command: one of [PQRS]
+CONTROL_PATTERN_UPPER_F_KEY = 4      # F5..F12                         : code 0x01 then 'b[' then the   dual-ord command:        [1][5789] or [2][0123] then the close '~'
 
-KEY_DEL = b"\x7f"
-ORD_DEL = ord(KEY_DEL)
 
+_PREVIOUS_ORD = ORD_NUL
 
-_PREVIOUS_ORD = 0
+_PRINTABLE_FOR_NONPRINTABLE = {
+    ORD_NUL: "(0)",
+    ORD_FKEY_START: "(F)",
+    ORD_BACKSPACE: "BS",
+    ORD_TAB: "TAB",
+    ORD_LF: "LF",
+    ORD_CR: "CR",
+    ORD_EOF: "EOF",
+    ORD_ESC: "ESC",
+    ORD_DEL: "DEL",
+}
 
 def __unused(*args):
     pass
@@ -22,8 +77,8 @@ def is_printable(char_ord):
     return char_ord > 31 and char_ord < 127
 
 
-def debug_str(in_charbyte):
-    return in_charbyte if is_printable(ord(in_charbyte)) else "?"
+def debug_str(in_ordinal):
+    return chr(in_ordinal) if is_printable(in_ordinal) else _PRINTABLE_FOR_NONPRINTABLE.get(in_ordinal, "?")
 
 
 # plink only sends CR (like classic macOS)
@@ -36,54 +91,93 @@ def _prompt(message="", *, input_=None, output=None, history=None, debug=False):
     output.write(message.encode("utf-8"))
     key_codes = []
     control_codes = []
+    control_pattern = CONTROL_PATTERN_NONE
     break_loop = False
-    while (not key_codes or _PREVIOUS_ORD not in [ord(KEY_CR), ord(KEY_LF)]) and not break_loop:
+    while (not key_codes or _PREVIOUS_ORD not in [ORD_CR, ORD_LF]) and not break_loop:
         in_char = input_.read(1)
-        in_ord = in_char[0]
-        debug(f"* received {in_ord:4}d {debug_str(in_char):4} previous {_PREVIOUS_ORD:4}")
+        in_ord = ord(in_char)
+        debug(f"* received {in_ord:4}d {debug_str(in_ord):4} previous {debug_str(_PREVIOUS_ORD):4}")
 
         if control_codes:
-            debug(f"** entering control char sequence {control_codes}")
             control_codes.append(in_ord)
-            if len(control_codes) == 2:
-                if in_ord != ORD_OPEN_BRACKET:
-                    debug(f"*** exiting control char sequence unsupported control code {in_ord:4}")
+            control_command_length = len(control_codes)
+            debug(f"** entering control char sequence {control_codes}")
+            if control_command_length == 2:
+                if control_codes[0] == ORD_ESC and in_ord == ORD_OPEN_BRACKET:
+                    # begin escape control sequence
+                    debug(f"** detected ESC control char sequence {control_codes}")
+                    control_pattern = CONTROL_PATTERN_MOVE_CURSOR_KEY  # Assume until further reads show otherwise
+                elif control_codes[0] == ORD_FKEY_START and in_ord == ORD_LOWER_B:
+                    # begin f-key control sequence
+                    debug(f"** detected F-key control char sequence {control_codes}")
+                    control_pattern = CONTROL_PATTERN_LOWER_F_KEY  # Assume until further reads show otherwise
+                else:
+                    debug(f"*** exiting control char sequence unsupported control code {debug_str(in_ord):4}")
+                    control_codes.clear()
+            elif control_command_length == 3:
+                if control_pattern == CONTROL_PATTERN_MOVE_CURSOR_KEY:
+                    if (ord("0") <= in_ord <= ord("9")):
+                        control_pattern = CONTROL_PATTERN_EDITOR_KEY  # We read more and learned we're reading an editor command
+                        debug(f"*** processing editor control code {debug_str(in_ord):4}")
+                    else:
+                        debug(f"*** completed move-cursor control code {debug_str(in_ord):4}")
+                        control_pattern = CONTROL_PATTERN_NONE
+                        control_codes.clear()
+                elif control_pattern == CONTROL_PATTERN_LOWER_F_KEY:
+                    if in_ord == ORD_OPEN_BRACKET:
+                        control_pattern = CONTROL_PATTERN_UPPER_F_KEY  # We read more and learned we're reading an upper F-key command
+                        debug(f"** detected upper F-key control char sequence {control_codes}")
+                    else:
+                        debug(f"*** processing lower F-key control code {debug_str(in_ord):4}")
+            elif control_command_length == 4:
+                if control_pattern == CONTROL_PATTERN_EDITOR_KEY:
+                    if in_ord == ORD_TILDE:
+                        debug(f"*** completed processing editor control code {debug_str(in_ord):4}")
+                        control_pattern = CONTROL_PATTERN_NONE
+                        control_codes.clear()
+                elif control_pattern == CONTROL_PATTERN_LOWER_F_KEY:
+                    debug(f"*** completed processing lower F-key control code {debug_str(in_ord):4}")
+                    control_pattern = CONTROL_PATTERN_NONE
                     control_codes.clear()
             else:
-                if (ord("0") <= in_ord <= ord("9")):
-                    debug(f"*** skipping control char sequence non-numeral control code {in_ord:4} {debug_str(in_char):4}")
-                else:
-                    debug(f"*** processing control code {in_ord:4}")
+                if in_ord == ORD_TILDE:
+                    debug(f"*** completed processing upper F-key control code {debug_str(in_ord):4}")
+                    control_pattern = CONTROL_PATTERN_NONE
                     control_codes.clear()
+                else:
+                    debug(f"*** processing upper F-key control code {debug_str(in_ord):4}")
             continue
-        if in_char in [KEY_ESCAPE]:
+
+        if in_ord in [ORD_ESC, ORD_FKEY_START]:
             debug("** detected control char sequence")
             control_codes.append(in_ord)
             continue
-        if in_char == KEY_LF and _PREVIOUS_ORD == ord(KEY_CR):
+
+        if in_ord == ORD_LF and _PREVIOUS_ORD == ORD_CR:
             # Throw away the line feed from Windows
             debug("** completed windows EOL")
             continue
-        if in_char in [KEY_CR, KEY_LF]:
+
+        if in_ord in [ORD_CR, ORD_LF]:
             # Do not capture EOL characters
             # Filter for more
-            # - F-keys start with \x01 and are either 2 more chars like 'bOP' 5 more chars like 'b[15~'
             # - Other non-printables
             # But allow
             # - Backspace \x08
             # - TAB \x09
             # - Delete
             debug("** skipped EOL char")
-            pass
+        elif in_ord in NOOP_ORDS:
+            debug(f"** skipped non printable char {in_ord}")
         else:
-            debug(f"** accepted {in_char}")
+            debug(f"** accepted {debug_str(in_ord)}")
             key_codes.append(in_ord)
 
         if in_ord == ORD_DEL:
             key_codes.pop()  # Remove the DEL char
             key_codes.pop()  # Remove the preceding char
             output.write(b"\b\x1b[K")  # Update the line
-        elif in_char in [KEY_CR, KEY_LF]:
+        elif in_ord in [ORD_CR, ORD_LF]:
             # Do not echo EOL characters back to the user
             debug("** matched loop exit")
             break_loop = True
@@ -91,7 +185,7 @@ def _prompt(message="", *, input_=None, output=None, history=None, debug=False):
             output.write(in_char)
 
         _PREVIOUS_ORD = in_ord
-        debug(f"\n** loop conditions key_codes: {key_codes} previous_ord: {_PREVIOUS_ORD} break: {break_loop}")
+        debug(f"\n** loop conditions key_codes: {key_codes} previous_ord: {debug_str(_PREVIOUS_ORD)} break: {break_loop}")
     output.write(b"\n")
     debug("encoded", key_codes)
 

--- a/tests/test_pysh_linebuffer.py
+++ b/tests/test_pysh_linebuffer.py
@@ -1,0 +1,276 @@
+"""Acceptance tests for the LineBuffer class in the pysh module."""
+
+import pytest
+
+from qtpy_sensor_node.snsr.pysh.py_shell import LineBuffer
+
+
+@pytest.mark.parametrize(
+    ("prompt_length"),
+    [
+        (len("")),
+        (len("qtpy $ ")),
+    ],
+)
+def test_initial_value(prompt_length: int) -> None:
+    """Does it initialize correctly?"""
+    buffy = LineBuffer(prompt_length=prompt_length)
+
+    assert buffy.input_cursor == 0
+    assert buffy.get_terminal_column() == 1 + prompt_length
+    assert not buffy.has_bytes()
+    assert not buffy.get_decoded_bytes()
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "expected_column"),
+    [
+        ("A", 2),
+        ("\t", 9),
+        ("abcd", 5),
+        ("1234\tabcd", 13),
+        ("aeio\t2468\t", 17),
+    ],
+)
+def test_accept_characters(input_characters: str, expected_column: int) -> None:
+    """Does it advance its index and column after accepting characters?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+
+    assert buffy.input_cursor == len(input_characters)
+    assert buffy.get_terminal_column() == expected_column
+    assert buffy.has_bytes()
+    assert buffy.get_decoded_bytes() == input_characters
+
+
+@pytest.mark.parametrize(
+    ("input_characters"),
+    [
+        (""),
+        ("\t"),
+        ("abcd"),
+        ("1234\tabcd"),  # fmt: skip -- each line holds a test case, don't flatten
+    ],
+)
+def test_move_home(input_characters: str) -> None:
+    """Does it correctly move the input cursor home?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+
+    # LineBuffer.move_home() can be called many times without changing the buffer's state
+    for _ in range(2):
+        buffy.move_home()
+
+        assert buffy.input_cursor == 0
+        assert buffy.get_terminal_column() == 1 + prompt_length
+        assert buffy.get_decoded_bytes() == input_characters
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "expected_column"),
+    [
+        ("", 1),
+        ("\t", 9),
+        ("abcd", 5),
+        ("1234\tabcd", 13),  # fmt: skip -- each line holds a test case, don't flatten
+    ],
+)
+def test_move_end(input_characters: str, expected_column: int) -> None:
+    """Does it correctly move the input cursor to the end?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    expected_cursor_position = len(input_characters)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+    buffy.move_home()
+
+    # LineBuffer.move_end() can be called many times without changing the buffer's state
+    for _ in range(2):
+        buffy.move_end()
+
+        assert buffy.input_cursor == expected_cursor_position
+        assert buffy.get_terminal_column() == expected_column
+        assert buffy.get_decoded_bytes() == input_characters
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "expected_cursor_and_column_after_move"),
+    [
+        (  # Moving left at the start of a line doesn't move the cursor or column
+            "",
+            [(0, 1), (0, 1)],
+        ),
+        (  # Moving left across characters moves both cursor and column
+            "abcd",
+            [(3, 4), (2, 3)],
+        ),
+        (  # Moving left across a tab character matches tab stops
+            "1234\tabcd",
+            [(8, 12), (7, 11), (6, 10), (5, 9), (4, 5)],
+        ),
+    ],
+)
+def test_move_left(input_characters: str, expected_cursor_and_column_after_move: list[tuple[int, int]]) -> None:
+    """Does it correctly move the input cursor left?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+
+    for expected_column_and_cursor in expected_cursor_and_column_after_move:
+        expected_cursor = expected_column_and_cursor[0]
+        expected_column = expected_column_and_cursor[1]
+        buffy.move_left()
+
+        assert buffy.input_cursor == expected_cursor
+        assert buffy.get_terminal_column() == expected_column
+        assert buffy.get_decoded_bytes() == input_characters
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "expected_cursor_and_column_after_move"),
+    [
+        (  # Moving right at the end of a line doesn't move the cursor or column
+            "",
+            [(0, 1), (0, 1)],
+        ),
+        (  # Moving right across characters moves both cursor and column
+            "abcd",
+            [(1, 2), (2, 3)],
+        ),
+        (  # Moving right across a tab character matches tab stops
+            "1234\tabcd",
+            [(1, 2), (2, 3), (3, 4), (4, 5), (5, 9)],
+        ),
+    ],
+)
+def test_move_right(input_characters: str, expected_cursor_and_column_after_move: list[tuple[int, int]]) -> None:
+    """Does it correctly move the input cursor right?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+    buffy.move_home()
+
+    for expected_column_and_cursor in expected_cursor_and_column_after_move:
+        expected_cursor = expected_column_and_cursor[0]
+        expected_column = expected_column_and_cursor[1]
+        buffy.move_right()
+
+        assert buffy.input_cursor == expected_cursor
+        assert buffy.get_terminal_column() == expected_column
+        assert buffy.get_decoded_bytes() == input_characters
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "left_moves", "expected_column", "expected_buffer"),
+    [
+        ("", 2, 1, ""),  # Deleting twice at the end of a line doesn't change the buffer
+        ("abcd", 2, 3, "abd"),
+        ("1234\tabcd", 5, 5, "1234abcd"),
+    ],
+)
+def test_delete(input_characters: str, left_moves: int, expected_column: int, expected_buffer: str) -> None:
+    """Does it correctly delete characters at the input cursor?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+    for _ in range(left_moves):
+        buffy.move_left()
+
+    terminal_column, remaining_line = buffy.delete()
+    assert terminal_column == expected_column
+    buffer = buffy.get_decoded_bytes()
+    assert buffer == expected_buffer
+    assert bytes(remaining_line) == buffer[buffy.input_cursor :].encode()
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "left_moves", "expected_column", "expected_buffer"),
+    [
+        ("", 2, 1, ""),  # Backspacing twice at the start of a line doesn't change the buffer
+        ("abcd", 2, 2, "acd"),
+        ("1234\tabcd", 4, 5, "1234abcd"),
+    ],
+)
+def test_backspace(input_characters: str, left_moves: int, expected_column: int, expected_buffer: str) -> None:
+    """Does it correctly backspace characters before the input cursor?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+    for _ in range(left_moves):
+        buffy.move_left()
+
+    terminal_column, remaining_line = buffy.backspace()
+    assert terminal_column == expected_column
+    buffer = buffy.get_decoded_bytes()
+    assert buffer == expected_buffer
+    assert bytes(remaining_line) == buffer[buffy.input_cursor :].encode()
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "move_calls", "expected_column", "expected_cursor"),
+    [
+        ("012345", ["move_home", "move_left"], 1, 0),
+        ("012345", ["move_home", "move_right"], 2, 1),
+        ("012345", ["move_home", "move_end", "move_right"], 7, 6),
+        ("012345", ["move_home", "move_end", "move_left"], 6, 5),
+        ("\t", ["move_left", "move_right"], 9, 1),
+        ("\tA", ["move_left", "move_left"], 1, 0),
+        ("B\t", ["move_home", "move_right", "move_right"], 9, 2),
+    ],
+)
+def test_line_navigation(
+    input_characters: str, move_calls: list[str], expected_column: int, expected_cursor: int
+) -> None:
+    """Does it handle multiple move commands correctly?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+
+    new_column = -1
+    for move_call in move_calls:
+        do_move = getattr(buffy, move_call)
+        new_column = do_move()
+
+    assert new_column == expected_column
+    assert buffy.input_cursor == expected_cursor
+
+
+@pytest.mark.parametrize(
+    ("input_characters", "buffer_calls", "expected_column", "expected_cursor", "expected_buffer"),
+    [
+        ("012345", ["move_left", "delete"], 6, 5, "01234"),
+        ("012345", ["backspace", "move_right"], 6, 5, "01234"),
+        ("012345", ["move_left", "delete", "move_right"], 6, 5, "01234"),
+        ("012345", ["move_home", "delete"], 1, 0, "12345"),
+        ("012345", ["move_home", "delete", "move_left"], 1, 0, "12345"),
+        ("012345", ["move_left", "move_left", "move_left", "backspace", "delete"], 3, 2, "0145"),
+        ("A\tB", ["move_left", "move_left", "delete"], 2, 1, "AB"),
+        ("C\tD", ["move_home", "move_right", "move_right", "backspace"], 2, 1, "CD"),
+    ],
+)
+def test_line_editing(
+    input_characters: str, buffer_calls: list[str], expected_column: int, expected_cursor: int, expected_buffer: str
+) -> None:
+    """Does it handle multiple move and edit commands correctly?"""
+    prompt_length = 0
+    buffy = LineBuffer(prompt_length=prompt_length)
+    for character in list(input_characters):
+        buffy.accept(ord(character))
+
+    for buffer_call in buffer_calls:
+        do_call = getattr(buffy, buffer_call)
+        do_call()
+
+    assert buffy.get_terminal_column() == expected_column
+    assert buffy.input_cursor == expected_cursor
+    assert buffy.get_decoded_bytes() == expected_buffer

--- a/tests/test_pysh_linebuffer.py
+++ b/tests/test_pysh_linebuffer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from qtpy_sensor_node.snsr.pysh.py_shell import LineBuffer
+from qtpy_sensor_node.snsr.pysh.linebuffer import LineBuffer
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pysh_py_shell.py
+++ b/tests/test_pysh_py_shell.py
@@ -56,7 +56,7 @@ def test_custom_shell_prompt() -> None:
     ],
 )
 def test_prompt_exits_on_eol(in_eol_bytes: bytes, assert_message: str) -> None:
-    """Does it return a repsonse after the EOL character?"""
+    """Does it return a response after the EOL character?"""
     shell_prompt = "qtpy $"
     input_buffer = io.BytesIO(initial_bytes=in_eol_bytes)
     output_buffer = io.BytesIO(initial_bytes=b"")

--- a/tests/test_pysh_py_shell.py
+++ b/tests/test_pysh_py_shell.py
@@ -1,0 +1,174 @@
+"""Acceptance tests for the custom_shell Circuit Python module."""
+
+import io
+import itertools
+
+import pytest
+
+from qtpy_sensor_node.snsr.pysh import py_shell
+
+_CODES_FOR_KEY_NAME = {
+    "left arrow": b"\x1b[D",
+    "right arrow": b"\x1b[C",
+    "up arrow": b"\x1b[A",
+    "down arrow": b"\x1b[B",
+    "home": b"\x1b[H",
+    "end": b"\x1b[F",
+    "backspace": b"\x08",
+    "delete": b"\x1b[3~",
+    "F1": b"\x01bOP",
+    "F2": b"\x01bOQ",
+    "F3": b"\x01bOR",
+    "F4": b"\x01bOS",
+    "F5": b"\x01b[15~",
+    "F6": b"\x01b[17~",
+    "F7": b"\x01b[18~",
+    "F8": b"\x01b[19~",
+    "F9": b"\x01b[20~",
+    "F10": b"\x01b[21~",
+}
+
+
+def test_custom_shell_prompt() -> None:
+    """Does it present the shell prompt?"""
+    shell_prompt = "qtpy $"
+    input_buffer = io.BytesIO(initial_bytes=b"")
+    output_buffer = io.BytesIO(initial_bytes=b"")
+    prompt_session = py_shell.PromptSession(in_stream=input_buffer, out_stream=output_buffer)
+
+    with pytest.raises(IndexError):
+        # Input stream is empty, and without the EOL character to end user input and exit the prompt loop,
+        # the backing io.BytesIO does not block on .read(1), unlike a serial port, and instead
+        # immediately returns an empty bytes array, which cannot be indexed for the first (and only) byte.
+        _ = prompt_session.prompt(message=shell_prompt)
+
+    actual_output = output_buffer.getvalue()
+    assert len(actual_output) > 0
+    assert actual_output == shell_prompt.encode("UTF-8")
+
+
+@pytest.mark.parametrize(
+    ("in_eol_bytes", "assert_message"),
+    [
+        (b"\n", "Linux EOL failed to complete user input"),
+        (b"\r", "Classic macOS EOL failed to complete user input"),
+        (b"\r\n", "Windows EOL failed to complete user input"),
+    ],
+)
+def test_prompt_exits_on_eol(in_eol_bytes: bytes, assert_message: str) -> None:
+    """Does it return a repsonse after the EOL character?"""
+    shell_prompt = "qtpy $"
+    input_buffer = io.BytesIO(initial_bytes=in_eol_bytes)
+    output_buffer = io.BytesIO(initial_bytes=b"")
+    prompt_session = py_shell.PromptSession(in_stream=input_buffer, out_stream=output_buffer)
+    response = prompt_session.prompt(message=shell_prompt)
+
+    expected_output = f"{shell_prompt}\n"
+    actual_output = output_buffer.getvalue()
+    assert len(actual_output) > 0
+    assert actual_output == expected_output.encode("UTF-8"), assert_message
+    assert len(response) == 0
+
+
+def test_printable_input() -> None:
+    """Does it echo printable user input back to the sender?"""
+    shell_prompt = "qtpy $"
+    printable_input = b"!'# 012 ABC abc ~\r\n"
+    input_buffer = io.BytesIO(initial_bytes=printable_input)
+    output_buffer = io.BytesIO(initial_bytes=b"")
+    prompt_session = py_shell.PromptSession(in_stream=input_buffer, out_stream=output_buffer)
+    response = prompt_session.prompt(message=shell_prompt)
+
+    # Room for improvement here -- rather than redrawing the most recent character when at the end of the buffer, just append it
+    expected_output = b"qtpy $\x1b[?25l\x1b[7G\x1b[0K!\x1b[8G\x1b[?25h\x1b[?25l\x1b[8G\x1b[0K'\x1b[9G\x1b[?25h\x1b[?25l\x1b[9G\x1b[0K#\x1b[10G\x1b[?25h\x1b[?25l\x1b[10G\x1b[0K \x1b[11G\x1b[?25h\x1b[?25l\x1b[11G\x1b[0K0\x1b[12G\x1b[?25h\x1b[?25l\x1b[12G\x1b[0K1\x1b[13G\x1b[?25h\x1b[?25l\x1b[13G\x1b[0K2\x1b[14G\x1b[?25h\x1b[?25l\x1b[14G\x1b[0K \x1b[15G\x1b[?25h\x1b[?25l\x1b[15G\x1b[0KA\x1b[16G\x1b[?25h\x1b[?25l\x1b[16G\x1b[0KB\x1b[17G\x1b[?25h\x1b[?25l\x1b[17G\x1b[0KC\x1b[18G\x1b[?25h\x1b[?25l\x1b[18G\x1b[0K \x1b[19G\x1b[?25h\x1b[?25l\x1b[19G\x1b[0Ka\x1b[20G\x1b[?25h\x1b[?25l\x1b[20G\x1b[0Kb\x1b[21G\x1b[?25h\x1b[?25l\x1b[21G\x1b[0Kc\x1b[22G\x1b[?25h\x1b[?25l\x1b[22G\x1b[0K \x1b[23G\x1b[?25h\x1b[?25l\x1b[23G\x1b[0K~\x1b[24G\x1b[?25h\n"
+    actual_output = output_buffer.getvalue()
+    assert len(actual_output) > 0
+    assert actual_output == expected_output
+    assert response == printable_input.decode("UTF-8").strip()
+
+
+@pytest.mark.parametrize(
+    ("input_key", "additional_expected_output_bytes"),
+    [
+        ("left arrow", b""),
+        ("right arrow", b""),
+        ("up arrow", b""),
+        ("down arrow", b""),
+        ("home", b""),
+        ("end", b""),
+        (  # impl always hides cursor, erases line, shows cursor
+            "backspace",
+            b"\x1b[?25l\x1b[7G\x1b[0K\x1b[7G\x1b[?25h",
+        ),
+        (  # impl always cursor, erases line, shows cursor
+            "delete",
+            b"\x1b[?25l\x1b[7G\x1b[0K\x1b[7G\x1b[?25h",
+        ),
+        ("F1", b""),
+        ("F2", b""),
+        ("F3", b""),
+        ("F4", b""),
+        ("F5", b""),
+        ("F6", b""),
+        ("F7", b""),
+        ("F8", b""),
+        ("F9", b""),
+        ("F10", b""),
+    ],
+)
+def test_nonprintable_input_key(input_key: str, additional_expected_output_bytes: bytes) -> None:
+    """Does it receive and handle non-printable user input?"""
+    shell_prompt = "qtpy $"
+    input_key_bytes = _CODES_FOR_KEY_NAME[input_key]
+    input_buffer = io.BytesIO(initial_bytes=input_key_bytes)
+    output_buffer = io.BytesIO(initial_bytes=b"")
+    prompt_session = py_shell.PromptSession(in_stream=input_buffer, out_stream=output_buffer)
+
+    with pytest.raises(IndexError):
+        # Because the input stream does not have the EOL character to end user input and exit the prompt loop,
+        # the backing io.BytesIO does not block on .read(1), unlike a serial port, and instead
+        # immediately returns an empty bytes array, which cannot be indexed for the first (and only) byte.
+        _ = prompt_session.prompt(message=shell_prompt)
+
+    expected_output = f"{shell_prompt}{additional_expected_output_bytes.decode('UTF-8')}"
+    actual_output = output_buffer.getvalue()
+    assert len(actual_output) > 0
+    assert actual_output == expected_output.encode("UTF-8")
+
+
+@pytest.mark.parametrize(
+    ("user_input", "input_command_sequence", "expected_response"),
+    [
+        ("012345", ["backspace"], "01234"),
+        ("012345", ["backspace", "right arrow"], "01234"),
+        ("012345", ["left arrow", "delete"], "01234"),
+        ("012345", ["left arrow", "delete", "right arrow"], "01234"),
+        ("012345", ["home", "delete"], "12345"),
+        ("012345", ["home", "delete", "left arrow"], "12345"),
+        ("012345", ["left arrow", "left arrow", "left arrow", "backspace", "delete"], "0145"),
+        ("\tFD\t", [], "\tFD\t"),
+        ("\tFD\t", ["left arrow"], "\tFD\t"),
+        ("\tFD\t", ["backspace"], "\tFD"),
+        ("\tFD\t", ["left arrow", "delete"], "\tFD"),
+        ("\tFD\t", ["home", "delete"], "FD\t"),
+    ],
+)
+def test_line_editing(user_input: str, input_command_sequence: list[str], expected_response: str) -> None:
+    """Does it correctly handle line editing commands?"""
+    shell_prompt = "qtpy $"
+    user_input_bytes = user_input.encode("UTF-8")
+    navigation_input_bytes = [_CODES_FOR_KEY_NAME[navkey] for navkey in input_command_sequence]
+    complete_input = bytearray(user_input_bytes)
+    complete_input.extend(itertools.chain.from_iterable(navigation_input_bytes))
+    complete_input.extend(b"\r\n")
+    complete_input_bytes = bytes(complete_input)
+
+    input_buffer = io.BytesIO(initial_bytes=complete_input_bytes)
+    output_buffer = io.BytesIO(initial_bytes=b"")
+    prompt_session = py_shell.PromptSession(in_stream=input_buffer, out_stream=output_buffer)
+    response = prompt_session.prompt(message=shell_prompt)
+
+    actual_output = output_buffer.getvalue()
+    assert len(actual_output) > 0
+    assert len(response) > 0
+    assert response == expected_response


### PR DESCRIPTION
## Summary

This change introduces `py_shell` -- a serial terminal shell program with line editing and command history. When used on a QT Py S3 device, opening a serial connection presents an interactive shell.

## Design

Reworked from https://github.com/adafruit/Adafruit_CircuitPython_Prompt_Toolkit

- Create a `LineBuffer` class to track the input cursor and terminal column positions as the user adds and removes characters.
- Complete the implementation of the core function `_prompt()` from the Adafruit prototype.
- Add diagnostics helpers to trace and log serial IO
- Add tests for `LineBuffer` and line editing in `PromptSession`

### Dismissed alternatives

1. Can we use `input()` to get a whole client-side edited line?
   - ✅ line editing
   - ✅ tab does autocomplete for names in Python globals(), not configurable
   - ✅ supports UTF-8 characters
   - ❌ mishandles F-keys by echoing the printable control codes and homing the cursor
1. Can we set a new wrapped function on the serial object?
   - ❌ No -- AttributeError: can't set attribute 'write'

## Screenshots or logs

![hello-py_shell](https://github.com/user-attachments/assets/0f70be6d-0636-4c25-8777-ab5ce76b53ee)

## Testing

New tests with these validations

- LineBuffer, for input strings with only single-space characters and strings mixed with tab characters
  - Does it initialize correctly?
  - Does it advance its index and column after accepting characters?
  - Does it correctly move the input cursor home?
  - Does it correctly move the input cursor to the end?
  - Does it correctly move the input cursor left?
  - Does it correctly move the input cursor right?
  - Does it correctly delete characters at the input cursor?
  - Does it correctly backspace characters before the input cursor?
  - Does it handle multiple move commands correctly?
  - Does it handle multiple move and edit commands correctly?
- PromptSession,
  - Does it present the shell prompt?
  - Does it return a response after the EOL character?
  - Does it echo printable user input back to the sender?
  - Does it receive and handle non-printable user input?
  - Does it correctly handle line editing commands?

## Checklist

- [x] Issues linked / labels applied
   - See #30 for the suggestions to improve speed and lower energy use
- [x] Documentation updated
   - See the new markdown file
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [ ] Ready to complete
