### PR TITLE
Add poe to the poetry environment in the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,11 @@ jobs:
 
     - name: Install dependencies
       run: |
+        poetry self add 'poethepoet[poetry_plugin]'
         poetry install
-        echo '## :package: Installed dependencies' >> $env:GITHUB_STEP_SUMMARY
+        echo '## :package: Installed plugins and dependencies' >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
+        poetry self show plugins >> $env:GITHUB_STEP_SUMMARY
         poetry show >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary

This change adds the `poe` plugin to the `poetry` environment in the CI pipeline.

## Design

Use `poetry self add 'poethepoet[poetry_plugin]'` when installing dependencies. See https://poethepoet.natn.io/installation.html#install-poe-the-poet-as-a-poetry-plugin.

## Screenshots or logs

See run of the pipeline in the checks below.

## Testing

See run of the pipeline in the checks below.

## Checklist

- [ ] ~~Issues linked / labels applied~~
- [ ] ~~Documentation updated~~
- [ ] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
