### PR TITLE
Remove spaces from build artifact name pattern add wheel package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,15 +106,23 @@ jobs:
       if: always()
 
     - name: Build package
-      run: poetry build --verbose --format sdist
+      run: poetry build --verbose
       if: always()
 
-    - name: Upload package
-      id: upload-package
+    - name: Upload source package
+      id: upload-source-package
       uses: actions/upload-artifact@v4
       with:
-        name: qtpy_datalogger for Python ${{ matrix.python_version }} on ${{ runner.os }}
+        name: qtpy_datalogger-py${{ matrix.python_version }}-${{ runner.os }}-source
         path: dist/*.tar.gz
+      if: always()
+
+    - name: Upload wheel package
+      id: upload-wheel-package
+      uses: actions/upload-artifact@v4
+      with:
+        name: qtpy_datalogger-py${{ matrix.python_version }}-${{ runner.os }}-wheel
+        path: dist/*.whl
       if: always()
 
     - name: Write workflow summary


### PR DESCRIPTION
## Summary

This PR removes the space characters from the build artifact file names, and it adds a Python wheel.

## Design

- Change the build step to also build a wheel package
- Add a job step that uploads the wheel

## Screenshots or logs

See checks below.

## Testing

See checks below.

## Checklist

_~~Strike~~ inapplicable items_

- [ ] ~~Issues linked / labels applied~~
- [ ] ~~Documentation updated~~
- [ ] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
