### PR TITLE
Fix download link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,5 +129,5 @@ jobs:
       run: |
         echo "## :test_tube: [Combined results](https://github.com/${{github.repository}}/runs/$($env:REPORT_ID)?check_suite_focus=true) :small_blue_diamond: ${{ steps.result-report.outputs.passed }} :white_check_mark: :small_blue_diamond: ${{ steps.result-report.outputs.failed }} :x: :small_blue_diamond: ${{ steps.result-report.outputs.skipped }} :next_track_button:" >> $env:GITHUB_STEP_SUMMARY
         echo '' >> $env:GITHUB_STEP_SUMMARY
-        echo '## :arrow_heading_down: [Download](${{ steps.upload-package.outputs.artifact-url }})' >> $env:GITHUB_STEP_SUMMARY
+        echo '## :arrow_heading_down: [Download](${{ steps.upload-wheel-package.outputs.artifact-url }})' >> $env:GITHUB_STEP_SUMMARY
       if: always()


### PR DESCRIPTION
## Summary

The download link in the CI summary page doesn't work. This PR fixes that.

## Design

Use the step id in the download link URL

## Screenshots or logs

See checks below.

## Testing

See checks below.

## Checklist

- [ ] ~~Issues linked / labels applied~~
- [ ] ~~Documentation updated~~
- [ ] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
