### PR TITLE
Ignore all updates for circuitpython-stubs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       interval: 'monthly'
     labels:
       - 'inbox'
+    ignore:
+      - dependency-name: "circuitpython-stubs"


### PR DESCRIPTION
## Summary

Do not let Dependabot automatically update the version of `circuitpython-stubs`. See #54 for more details.

## Design

Use the `ignore` list -- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-disabling-version-updates-for-some-dependencies

## Screenshots or logs

_None_

## Testing

The PR build tests this chage.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [ ] Tests passed
- [ ] Analyzers passed
- [ ] Ready to complete
