### PR TITLE
[drafting] Add server command to interact with the MQTT broker service

### DIFF
--- a/src/qtpy_datalogger/console.py
+++ b/src/qtpy_datalogger/console.py
@@ -159,6 +159,12 @@ def equip(behavior: str, root: pathlib.Path | None) -> None:
     default=True,
     help="Behavior: [default] Show the current status of the service.",
 )
+@click.option(
+    "--restart",
+    "behavior",
+    flag_value=_server.Behavior.Restart,
+    help="Behavior: Restart the service, requires Administrator privileges.",
+)
 @click.help_option()
 def server(behavior: str) -> None:
     """Query and control the MQTT server."""

--- a/src/qtpy_datalogger/console.py
+++ b/src/qtpy_datalogger/console.py
@@ -171,11 +171,18 @@ def equip(behavior: str, root: pathlib.Path | None) -> None:
     flag_value=_server.Behavior.Restart,
     help="Behavior: Restart the service, requires Administrator privileges.",
 )
+@click.option(
+    "--publish",
+    nargs=2,
+    type=(str, str),
+    metavar="TOPIC MESSAGE",
+    help="Send a MESSAGE to the service on the specified TOPIC.",
+)
 @click.help_option()
-def server(behavior: str) -> None:
+def server(behavior: str, publish: tuple[str, str]) -> None:
     """Query and control the MQTT server."""
     server_behavior = _server.Behavior(behavior)
-    _server.handle_server(server_behavior)
+    _server.handle_server(server_behavior, publish)
 
 
 def get_logging_level(quiet: bool, verbose: bool) -> int:

--- a/src/qtpy_datalogger/console.py
+++ b/src/qtpy_datalogger/console.py
@@ -160,6 +160,12 @@ def equip(behavior: str, root: pathlib.Path | None) -> None:
     help="Behavior: [default] Show the current status of the service.",
 )
 @click.option(
+    "--observe",
+    "behavior",
+    flag_value=_server.Behavior.Observe,
+    help="Behavior: Monitor the service and print published messages, Ctrl-C to quit.",
+)
+@click.option(
     "--restart",
     "behavior",
     flag_value=_server.Behavior.Restart,

--- a/src/qtpy_datalogger/console.py
+++ b/src/qtpy_datalogger/console.py
@@ -7,6 +7,7 @@ import click
 
 from . import discovery, tracelog
 from . import equip as _equip
+from . import server as _server
 from .datatypes import Links
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,21 @@ def equip(behavior: str, root: pathlib.Path | None) -> None:
     """Install the QT Py Sensor Node runtime on a CircuitPython device."""
     equip_behavior = _equip.Behavior(behavior)
     _equip.handle_equip(equip_behavior, root)
+
+
+@cli.command(epilog=f"Detailed help online\n\n{Links.MQTT_Walkthrough}")
+@click.option(
+    "--describe",
+    "behavior",
+    flag_value=_server.Behavior.Describe,
+    default=True,
+    help="Behavior: [default] Show the current status of the service.",
+)
+@click.help_option()
+def server(behavior: str) -> None:
+    """Query and control the MQTT server."""
+    server_behavior = _server.Behavior(behavior)
+    _server.handle_server(server_behavior)
 
 
 def get_logging_level(quiet: bool, verbose: bool) -> int:

--- a/src/qtpy_datalogger/datatypes.py
+++ b/src/qtpy_datalogger/datatypes.py
@@ -22,6 +22,7 @@ class Links(enum.StrEnum):
     Homepage = "https://github.com/wireddown/qt-py-s3-daq-app/wiki"
     New_Bug = "https://github.com/wireddown/qt-py-s3-daq-app/issues/new?template=bug-report.md"
     Board_Support_Matrix = "https://docs.circuitpython.org/en/stable/shared-bindings/support_matrix.html"
+    MQTT_Walkthrough = "https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT"
 
 
 class ExitCode(enum.IntEnum):
@@ -31,6 +32,9 @@ class ExitCode(enum.IntEnum):
     Discovery_Failure = 41
     COM1_Failure = 42
     Board_Lookup_Failure = 51
+    Server_Missing_Failure = 61
+    Server_Offline_Failure = 62
+    Server_Inaccessible_Failure = 63
 
 
 class CaptionCorrections:

--- a/src/qtpy_datalogger/server.py
+++ b/src/qtpy_datalogger/server.py
@@ -1,0 +1,298 @@
+"""Functions to interact with the MQTT broker that handles the network communication."""
+
+import logging
+import pathlib
+import re
+import subprocess
+import sys
+import time
+from enum import StrEnum
+from typing import Callable, NamedTuple
+
+from .datatypes import ExitCode, Links
+
+logger = logging.getLogger(__name__)
+
+
+class Behavior(StrEnum):
+    """Supported behaviors for server interaction."""
+
+    Describe = "Describe"
+    # Observe = "Observe"
+    # Restart = "Restart"
+
+
+class BrokerOption(NamedTuple):
+    """Represents an option name and value for an MQTT broker."""
+
+    name: str
+    value: str
+
+
+class FirewallRule(NamedTuple):
+    """Represents the settings for a firewall rule."""
+
+    name: str
+    enabled: str
+    local_port: str
+    remote_ip: str
+    action: str
+
+
+class MqttBrokerInformation(NamedTuple):
+    """Holds details about the MQTT broker's service, configuration, and firewall status."""
+
+    description: str
+    server_runmode: str
+    server_health: str
+    server_startmode: str
+    server_executable: pathlib.Path
+    server_configuration: list[BrokerOption]
+    firewall_rules: list[FirewallRule]
+
+    @property
+    def server_options(self) -> dict[str, str]:
+        """Return server_configuration as a dictionary with (name, value) entries."""
+        options = {option.name: option.value for option in self.server_configuration}
+        return options
+
+    @property
+    def has_enabled_firewall_rules(self) -> bool:
+        """Return True if the system has firewall rules enabled for the MQTT broker service."""
+        return any(rule.enabled == "Yes" for rule in self.firewall_rules)
+
+    @property
+    def has_allowed_firewall_rules(self) -> bool:
+        """Return True if the system's firewall rules for the MQTT broker service allow external connections."""
+        return any(rule.action == "Allow" for rule in self.firewall_rules)
+
+
+def handle_server(behavior: Behavior) -> None:
+    """Handle the command for server."""
+    mqtt_broker_information = _query_mqtt_broker_information_from_wmi()
+    if not mqtt_broker_information:
+        logger.error("MQTT broker is not a registered service. Is it installed?")
+        logger.error("  Visit 'https://mosquitto.org/download/' to download it")
+        raise SystemExit(ExitCode.Server_Missing_Failure)
+
+    message_lines_with_level = _analyze_mqtt_broker(mqtt_broker_information)
+    did_warn = False
+    logger.info("")
+    for line_and_level in message_lines_with_level:
+        line = line_and_level[0]
+        level = line_and_level[1]
+        did_warn |= level >= logging.WARNING
+        logger.log(level, line)
+    logger.info("")
+
+    if behavior == Behavior.Describe and did_warn:
+        logger.error("MQTT server is not configured to support sensor nodes!")
+        logger.error(f"  Visit {Links.MQTT_Walkthrough} to learn more")
+        raise SystemExit(ExitCode.Server_Inaccessible_Failure)
+
+
+def _analyze_mqtt_broker(broker_information: MqttBrokerInformation) -> list[tuple[str, int]]:
+    """Analyze the availability and accessibility of the MQTT broker service."""
+    running_line = f"{'State':>12}  {broker_information.server_runmode}"
+    running_level = logging.INFO
+    if broker_information.server_runmode != "Running":
+        logger.warning("MQTT broker is not running!")
+        logger.warning("  Try 'qtpy-datalogger server --restart'")
+        running_level = logging.WARNING
+
+    server_level = logging.INFO
+    server_options = broker_information.server_options
+    if not server_options:
+        mqtt_conf_message = "Unconfigured"
+        server_level = logging.WARNING
+        logger.warning("MQTT broker is not configured to listen for connections!")
+        logger.warning("  Update the configuration file to listen on port 1883 and restart the service")
+    else:
+        mqtt_conf_message = f"Listening on port {server_options['listener']}"
+    server_line = f"{'Server':>12}  {mqtt_conf_message}"
+
+    # Evaluate firewall rules by increasing severity
+    firewall_message = "Open on port 1883"
+    firewall_level = logging.INFO
+    if not broker_information.has_allowed_firewall_rules:
+        firewall_message = "Blocked"
+        firewall_level = logging.WARNING
+        logger.warning("All firewall rules for MQTT connections do not allow connections!")
+        logger.warning("  Try 'wf.msc' to allow with Administrator privileges")
+    if not broker_information.has_enabled_firewall_rules:
+        firewall_message = "Disabled"
+        firewall_level = logging.WARNING
+        logger.warning("All firewall rules for MQTT connections are disabled!")
+        logger.warning("  Try 'wf.msc' to enable with Administrator privileges")
+    if not broker_information.firewall_rules:
+        firewall_message = "Unconfigured"
+        firewall_level = logging.WARNING
+        logger.warning("This computer's firewall has no rules that support MQTT connections!")
+        logger.warning("  Run the following in a terminal with Administrator privileges")
+        firewall_rule_command = _get_firewall_rule_for_windows()
+        logger.info("")
+        logger.info(firewall_rule_command)
+        logger.info("")
+    firewall_line = f"{'Firewall':>12}  {firewall_message}"
+
+    broker_analysis = [
+        (broker_information.description, logging.INFO),
+        (running_line, running_level),
+        (f"{'Status':>12}  {broker_information.server_health}", logging.INFO),
+        (f"{'Startup':>12}  {broker_information.server_startmode}", logging.INFO),
+        (f"{'Executable':>12}  {broker_information.server_executable!s}", logging.INFO),
+        (server_line, server_level),
+        (firewall_line, firewall_level),
+    ]
+    return broker_analysis
+
+
+def _query_mqtt_broker_information_from_wmi() -> MqttBrokerInformation | None:
+    """Query the system for information about the MQTT broker service, configuration, and relevant firewall rules."""
+    from wmi import WMI
+
+    host_pc = WMI()
+    matching_services = sorted(host_pc.Win32_Service(Name="mosquitto"))
+    if not matching_services:
+        return None
+
+    mqtt_broker = matching_services[0]
+
+    # Paths that have spaces use double-quotes, typically for the "Program Files" segment
+    #   No-space  'C:\\WINDOWS\\System32\\svchost.exe -k LocalSystemNetworkRestricted -p'
+    #   With-space '"C:\\Program Files\\mosquitto\\mosquitto.exe" run'
+    path_parts = mqtt_broker.PathName.split('"')
+    broker_executable = path_parts[0].split(" ")[0] if path_parts[0] else path_parts[1]
+    broker_executable_path = pathlib.Path(broker_executable)
+
+    server_config = _query_mqtt_broker_configuration_from_file(broker_executable_path)
+    matching_port_rules = _query_firewall_port_rules_from_netsh()
+
+    broker_information = MqttBrokerInformation(
+        description=mqtt_broker.Description,
+        server_runmode=mqtt_broker.State,
+        server_health=mqtt_broker.Status,
+        server_startmode=mqtt_broker.StartMode,
+        server_executable=broker_executable_path,
+        server_configuration=server_config,
+        firewall_rules=matching_port_rules,
+    )
+    logger.debug(broker_information)
+    return broker_information
+
+
+def _query_mqtt_broker_configuration_from_file(broker_executable: pathlib.Path) -> list[BrokerOption]:
+    """Read and parse a subset of options from the MQTT server's configuration file."""
+    broker_configuration = broker_executable.with_name("mosquitto.conf")
+    if not broker_configuration.exists():
+        logger.warning("Could not read MQTT configuration file")
+        logger.warning(f"  The file '{broker_configuration!s}' does not exist")
+        return []
+
+    # From the server configuration file, parse interesting options
+    configuration_lines = broker_configuration.read_text().splitlines()
+    interesting_options = [
+        "listener",
+        "allow_anonymous",
+    ]
+    found_options = []
+    for line in configuration_lines:
+        if any(line.startswith(option) for option in interesting_options):
+            name_value_pair = [cell.strip() for cell in line.split(" ")]
+            option = BrokerOption(
+                name=name_value_pair[0],
+                value=name_value_pair[1],
+            )
+            found_options.append(option)
+            logger.debug(line)
+    return found_options
+
+
+def _query_firewall_port_rules_from_netsh(port_to_match: int = 1883) -> list[FirewallRule]:
+    """Query and parse firewall rules on the system that control MQTT broker port 1883."""
+    get_all_firewall_rules = [
+        "netsh",
+        "advfirewall",
+        "firewall",
+        "show",
+        "rule",
+        "name=all",
+    ]
+    result = subprocess.run(get_all_firewall_rules, capture_output=True, check=False)  # noqa: S603 -- command is well-formed and user cannot execute arbitrary code
+    if result.returncode != 0:
+        logger.warning("Could not query for firewall settings")
+        _ = [logger.warning(line) for line in result.stderr.decode("UTF-8")]
+        return []
+
+    # The output is very large, so quickly identify the LocalPort lines with a regex match
+    line_with_port_pattern = re.compile(rf"LocalPort:\s+{port_to_match}")
+    full_report = result.stdout.decode("UTF-8").splitlines()
+    matching_port_indexes = []
+    for index, line in enumerate(full_report):
+        if line_with_port_pattern.match(line):
+            matching_port_indexes.append(index)
+
+    # Using the LocalPort line as a reference point, select the preceding and following lines that describe the entire rule
+    matching_rule_line_groups = []
+    for matching_port_index in matching_port_indexes:
+        first_line = matching_port_index - 9
+        last_line = matching_port_index + 4
+        rule_lines = full_report[first_line:last_line]
+        _ = rule_lines.pop(1)  # Remove the "-------" title-details separator line
+        matching_rule_line_groups.append(rule_lines)
+
+    # From each rule, parse interesting fields that describe the firewall rule
+    rules = []
+    interesting_fields = [
+        "Rule Name",
+        "Enabled",
+        "LocalPort",
+        "RemoteIP",
+        "Action",
+    ]
+    for rule_line_group in matching_rule_line_groups:
+        rule_info = {}
+        for line in rule_line_group:
+            logger.debug(line)
+            if any(line.startswith(field) for field in interesting_fields):
+                name_value_pair = [cell.strip() for cell in line.split(":")]
+                field_name = name_value_pair[0]
+                field_value = name_value_pair[1]
+                rule_info[field_name] = field_value
+        logger.debug("")
+        rule = FirewallRule(
+            name=rule_info["Rule Name"],
+            enabled=rule_info["Enabled"],
+            local_port=rule_info["LocalPort"],
+            remote_ip=rule_info["RemoteIP"],
+            action=rule_info["Action"],
+        )
+        rules.append(rule)
+
+    _ = [logger.debug(rule) for rule in rules]
+    return rules
+
+
+def _get_firewall_rule_for_windows() -> str:
+    """Return the netsh command that adds a firewall rule to allow inbound connections on port 1883 from the local subnet."""
+    command_as_list = [
+        "netsh",
+        "advfirewall",
+        "firewall",
+        "add",
+        "rule",
+        "name='Mosquitto MQTT: allow inbound on port 1883 from local subnet'",
+        "program='%ProgramFiles%\\mosquitto\\mosquitto.exe'",
+        "dir=in",
+        "action=allow",
+        "service=any",
+        "description='This rule allows MQTT clients on the local subnet to connect to this host'",
+        "profile=private",
+        "localip=any",
+        "remoteip=localsubnet",
+        "localport=1883",
+        "remoteport=any",
+        "protocol=tcp",
+        "interfacetype=any",
+    ]
+    return " ".join(command_as_list)


### PR DESCRIPTION
## Summary

This change adds a new command named `server` that allows a caller to query and control the MQTT broker service.

This command expects to query and control a `mosquitto` service instance on Windows.

## Design

**console.py**

- Add new command named `server` with these options
  - `--describe` -- _(default)_ show the current status of the service
  - `--observe` -- monitor the service and print messages published to the `qtpy/...` topic tree
  - `--restart` -- restart the service, requires Administrator privileges
  - `--publish TOPIC MESSAGE` -- send a free-form **MESSAGE** to the service on the specified **TOPIC**

**datatypes.py**

- Add new URL for MQTT broker walkthrough wiki page, used by the help for the command
  - https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT
- Add exit error codes for different incorrect outcomes
  - Missing -- the server is not installed
  - Offline -- the server is not started
  - Inaccessible -- the server is not configured or the firewall is blocking the server

**server.py** -- new file ✨

- Add data classes to describe the server configuration
  - `BrokerOption` -- represents an option name and value for an MQTT broker
  - `FirewallRule` -- represents the settings for a firewall rule
  - `MqttBrokerInformation` -- holds details about the MQTT broker's service, configuration, and firewall status
- Add procedural subroutines to learn about the service and firewall settings
  - `_query_mqtt_broker_information_from_wmi()` -- query the system for information about the MQTT broker service, configuration, and relevant firewall rules
    - `_query_mqtt_broker_configuration_from_file()` -- read and parse a subset of options from the MQTT server's configuration file
    - `_query_firewall_port_rules_from_netsh()` -- query and parse firewall rules on the system that control MQTT broker port 1883
  - `_analyze_mqtt_broker()` -- analyze the availability and accessibility of the MQTT broker service
  - `_get_firewall_rule_for_windows()` -- return the netsh command that adds a firewall rule to allow inbound connections on port 1883 from the local subnet
- Add `_restart_mqtt_broker_with_wmi()` to control the MQTT broker service
- With `--observe`, use the companion program `mosquitto_sub.exe` to subscribe to the messages under the `qtpy/...` topic tree
- With `--publish`, use the companion program `mosquitto_pub.exe` to send the message to the server

## Screenshots or logs

### Command help

**`> qtpy-datalogger server --help`**

```
Usage: qtpy-datalogger server [OPTIONS]

  Query and control the MQTT server.

Options:
  --describe               Behavior: [default] Show the current status of the
                           service.
  --observe                Behavior: Monitor the service and print published
                           messages, Ctrl-C to quit.
  --restart                Behavior: Restart the service, requires
                           Administrator privileges.
  --publish TOPIC MESSAGE  Send a MESSAGE to the service on the specified
                           TOPIC.
  --help                   Show this message and exit.

  Detailed help online

  https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT
```

### Typical outcome

**`> qtpy-datalogger server`**

```
INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
INFO         Firewall  Open on port 1883
```

### Monitor the server for all qtpy messages

**`> qtpy-datalogger server --observe`**

```
INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
INFO         Firewall  Open on port 1883

INFO     Subscribing with 'C:\Program Files\mosquitto\mosquitto_sub.exe --id qtpy-datalogger-sub --topic $SYS/# --unsubscribe $SYS/# --topic qtpy/# -F %j'
INFO     Use Ctrl-C to quit
{"tst":"2025-03-26T16:37:52.990000-0700","topic":"$SYS/broker/version","qos":0,"retain":1,"payloadlen":24,"payload":"mosquitto version 2.0.20"}
{"tst":"2025-03-26T16:37:52.990000-0700","topic":"$SYS/broker/uptime","qos":0,"retain":1,"payloadlen":14,"payload":"281165 seconds"}
{"tst":"2025-03-26T16:37:52.990000-0700","topic":"$SYS/broker/clients/total","qos":0,"retain":1,"payloadlen":1,"payload":"0"}
{"tst":"2025-03-26T16:37:52.990000-0700","topic":"$SYS/broker/clients/inactive","qos":0,"retain":1,"payloadlen":1,"payload":"0"}
...
```

### Publish a message to the server

**`> qtpy-datalogger server --publish qtpy/v1 "test message"`**

```
INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
INFO         Firewall  Open on port 1883

INFO     Publishing with 'C:\Program Files\mosquitto\mosquitto_pub.exe --id qtpy-datalogger-pub --topic qtpy/v1 --message test message'
```

## Testing

There are no automated tests for this command because this project uses public GitHub runners and installing services is not possible. Further, the actions taken by this command are procedural subroutines that do not have complex behavior or state.

When finding and fixing bugs, we shall rely on the `--verbose` messages revealing the differences in the runtime environment or the logic errors in the code.

I did some interactive testing, however, on Windows 11.

### Server is not installed

**`> qtpy-datalogger server`**

```
ERROR    MQTT broker is not a registered service. Is it installed?
ERROR      Visit 'https://mosquitto.org/download/' to download it
```

### Server is not running

**`> qtpy-datalogger server`**

```
WARNING  MQTT broker is not running!
WARNING    Try 'qtpy-datalogger server --restart'

INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
WARNING         State  Stopped
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
INFO         Firewall  Open on port 1883

ERROR    MQTT server is not configured to support sensor nodes!
ERROR      Visit https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT to learn more
```

### Server is not configured to listen for clients

**`> qtpy-datalogger server`**

```
WARNING  MQTT broker is not configured to listen for connections!
WARNING    Update the configuration file to listen on port 1883 and restart the service

INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
WARNING        Server  Unconfigured
INFO         Firewall  Open on port 1883

ERROR    MQTT server is not configured to support sensor nodes!
ERROR      Visit https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT to learn more
```

### Firewall has no rules

**`> qtpy-datalogger server`**

```
WARNING  All firewall rules for MQTT connections do not allow connections!
WARNING    Try 'wf.msc' to allow with Administrator privileges
WARNING  All firewall rules for MQTT connections are disabled!
WARNING    Try 'wf.msc' to enable with Administrator privileges
WARNING  This computer's firewall has no rules that support MQTT connections!
WARNING    Run the following in a terminal with Administrator privileges

INFO     netsh advfirewall firewall add rule name='Mosquitto MQTT: allow inbound on port 1883 from local subnet' program='%ProgramFiles%\mosquitto\mosquitto.exe' dir=in action=allow service=any description='This rule allows MQTT clients on the local subnet to connect to this host' profile=private localip=any remoteip=localsubnet localport=1883 remoteport=any protocol=tcp interfacetype=any


INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
WARNING      Firewall  Unconfigured

ERROR    MQTT server is not configured to support sensor nodes!
ERROR      Visit https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT to learn more
```

### Firewall rules block clients

**`> qtpy-datalogger server`**

```
WARNING  All firewall rules for MQTT connections do not allow connections!
WARNING    Try 'wf.msc' to allow with Administrator privileges

INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
WARNING      Firewall  Blocked

ERROR    MQTT server is not configured to support sensor nodes!
ERROR      Visit https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT to learn more
```

### Firewall rules for the service are disabled

**`> qtpy-datalogger server`**

```
WARNING  All firewall rules for MQTT connections are disabled!
WARNING    Try 'wf.msc' to enable with Administrator privileges

INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
WARNING      Firewall  Disabled

ERROR    MQTT server is not configured to support sensor nodes!
ERROR      Visit https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT to learn more
```

## Checklist

- [x] Issues linked / labels applied
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
