### PR TITLE
Use zone1 as the default MQTT group name

### DIFF
--- a/src/qtpy_datalogger/network.py
+++ b/src/qtpy_datalogger/network.py
@@ -358,7 +358,7 @@ def open_session_on_node(node_id: str) -> None:
 async def _query_nodes_from_mqtt() -> dict[str, dict[DetailKey, str]]:
     """Use a new QTPyController to scan the network for sensor_nodes."""
     broker_host = "localhost"
-    group_id = "centrifuge"
+    group_id = "zone1"  # See https://github.com/wireddown/qt-py-s3-daq-app/issues/60
     mac_address = hex(uuid.getnode())[2:]
     ip_address = socket.gethostbyname(socket.gethostname())
     controller = QTPyController(
@@ -378,7 +378,7 @@ async def _query_nodes_from_mqtt() -> dict[str, dict[DetailKey, str]]:
 async def _open_session_on_node(node_id: str) -> None:
     """Use a new QTPyController to open a terminal session on the specified node_id."""
     broker_host = "localhost"
-    group_id = "centrifuge"
+    group_id = "zone1"  # See https://github.com/wireddown/qt-py-s3-daq-app/issues/60
     mac_address = hex(uuid.getnode())[2:]
     ip_address = socket.gethostbyname(socket.gethostname())
     controller = QTPyController(

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -12,7 +12,7 @@ boot_time = monotonic()
 print(f"Booted at {boot_time:.3f}")  # noqa: T201 -- use direct IO for user REPL
 radio = connect_to_wifi()
 
-node_group = os.getenv("QTPY_NODE_GROUP", "")
+node_group = os.getenv("QTPY_NODE_GROUP", "zone1")  # See https://github.com/wireddown/qt-py-s3-daq-app/issues/60
 node_identifier = f"node-{cpu.uid.hex().lower()}-0"  # Matches boot_out.txt
 mqtt_topics = [
     f"qtpy/v1/{node_group}/broadcast",

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -157,7 +157,7 @@ def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> st
     from snsr.node.mqtt import format_mqtt_client_id, get_descriptor_topic
 
     pid = 0
-    group_id = "centrifuge"
+    group_id = os.getenv("QTPY_NODE_GROUP", "zone1")  # See https://github.com/wireddown/qt-py-s3-daq-app/issues/60
 
     descriptor = build_descriptor_information(role, serial_number, ip_address)
     client_id = format_mqtt_client_id(role, serial_number, pid)

--- a/tests/test_node_classes.py
+++ b/tests/test_node_classes.py
@@ -28,7 +28,7 @@ def reference_descriptor_payload() -> str:
                 }
             },
             "sender": {
-                "descriptor_topic": "qtpy/v1/centrifuge/host-12ab34cd56ef-1213/$DESCRIPTOR",
+                "descriptor_topic": "qtpy/v1/zone1/host-12ab34cd56ef-1213/$DESCRIPTOR",
                 "sent_at": "2025-03-14T17:15:25-07:00",
                 "status": {
                     "used_memory": "1889785610",
@@ -51,7 +51,7 @@ def reference_identify_payload() -> str:
                 "message_id": "identify-1"
             },
             "sender": {
-                "descriptor_topic": "qtpy/v1/centrifuge/host-12ab34cd56ef-1213/$DESCRIPTOR",
+                "descriptor_topic": "qtpy/v1/zone1/host-12ab34cd56ef-1213/$DESCRIPTOR",
                 "sent_at": "2025-03-14T17:15:25-07:00",
                 "status": {
                     "used_memory": "1889785610",


### PR DESCRIPTION
## Summary

This change generalizes the first default group name as `zone1`.

This is an interim behavior while #60 is open.

## Design

- Replace hardcoded values with new default value.
- Use `settings.toml` when running on a node

## Screenshots or logs

🚫

## Testing

The PR checks cover this change.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
