### PR TITLE
Allow running the CI on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run Tests and Analyzers
+name: 'CI: Tests and Analyzers'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Run Tests and Analyzers
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A data acquisition application using the [Adafruit QT Py S3] and [CircuitPython].
 
-[![Run Tests and Analyzers]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml?query=branch%3Amain) [![Dependabot Updates]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates)
+[![CI: Tests and Analyzers]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml?query=branch%3Amain) [![Dependabot Updates]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates)
 
 ## Structure
 


### PR DESCRIPTION
## Summary

This PR changes the CI action so that we can run it on demand.

## Design

Add the `workflow_dispatch` event.

## Screenshots or logs

Cannot do preflight testing because [this event must be in the default branch](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#configuring-a-workflow-to-run-manually) to run.

## Testing

This becomes possible after we complete this PR.

## Checklist

_~~Strike~~ inapplicable items_

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] ~~Tests passed~~
- [x] ~~Analyzers passed~~
- [x] Ready to complete
