### PR TITLE
CircuitPython package discovery: Fix behavior and test

### DIFF
--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -520,7 +520,8 @@ def _handle_list_builtin_modules(board_id: str) -> str:
 
     # We define these as functions to reclaim their memory usage from parsing the HTML contents, which can be very large
     def fetch_find_extract_builtin_modules_for_board_id(reference_url: str, board_id: str) -> tuple[str, list[str]]:
-        live_html_bytes = urllib.request.urlopen(reference_url).read()  # noqa: S310 -- URL is hardcoded to https
+        page_request = urllib.request.Request(reference_url, headers={"User-agent": "Mozilla/5.0"})  # noqa: S310 -- URL is hardcoded to https
+        live_html_bytes = urllib.request.urlopen(page_request).read()  # noqa: S310 -- URL is hardcoded to https
         live_html = live_html_bytes.decode("UTF-8")
         soup = bs4.BeautifulSoup(live_html, "html.parser")
         page_title = soup.title.text.split("-")[0].strip()  # pyright: ignore
@@ -548,7 +549,8 @@ def _handle_list_builtin_modules(board_id: str) -> str:
         return reference_version, builtin_module_names
 
     def fetch_find_extract_standard_library_modules(reference_url: str) -> list[str]:
-        live_html_bytes = urllib.request.urlopen(reference_url).read()  # noqa: S310 -- URL is hardcoded to https
+        page_request = urllib.request.Request(reference_url, headers={"User-agent": "Mozilla/5.0"})  # noqa: S310 -- URL is hardcoded to https
+        live_html_bytes = urllib.request.urlopen(page_request).read()  # noqa: S310 -- URL is hardcoded to https
         live_html = live_html_bytes.decode("UTF-8")
         soup = bs4.BeautifulSoup(live_html, "html.parser")
         the_stdlib_section = soup.find(id="python-standard-libraries")

--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -569,7 +569,7 @@ def _handle_list_builtin_modules(board_id: str) -> str:
 
     full_contents = {
         "reference": reference_version,
-        "urls": [Links.Board_Support_Matrix, standard_library_page],
+        "urls": [Links.Board_Support_Matrix.value, standard_library_page],
         "standard_library": stdlib_module_names,
         board_id: builtin_module_names,
     }

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -81,4 +81,5 @@ def test_list_builtin_modules(tmp_path: pathlib.Path) -> None:
     assert output_file.exists()
     all_lines = output_file.read_text().splitlines()
     assert all_lines[0].startswith('reference = "Adafruit CircuitPython')
+    assert all_lines[1].startswith('urls = [ "https://docs.circuitpython.org/')
     assert all_lines[-1].startswith('"Adafruit QT Py ESP32-S3 no psram" = [ "_asyncio",')


### PR DESCRIPTION
## Summary

At some point, **docs.circuitpython.org** started refusing HTTP requests that didn't have the `User-agent` header. This caused the test for `--list-builtin-modules ` to fail because it queries their live data.

## Design

- Add the default GUI user agent identifier `Mozilla/5.0` to HTTP requests
- Also validate that the toml output correctly lists the URL references

## Screenshots or logs

- See PR checks

## Testing

- I added an assert that the URL reference array looks like an array of strings

## Checklist

_~~Strike~~ inapplicable items_

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
