### PR TITLE
Fix CI badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A data acquisition application using the [Adafruit QT Py S3] and [CircuitPython].
 
-[![CI: Tests and Analyzers]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml?query=branch%3Amain) [![Dependabot Updates]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates)
+[![CI: Tests and Analyzers](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml/badge.svg)](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml)
+[![Dependabot Updates]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates)
 
 ## Structure
 


### PR DESCRIPTION
## Summary

This PR restores the CI badge on the README, which wasn't rendering.

## Design

- Re-get the badge markdown from the Actions page.
- Put each badge on its own line for readability

## Screenshots or logs

See preview.

## Testing

See preview.

## Checklist

_~~Strike~~ inapplicable items_

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
