### PR TITLE
Use default labels for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-    labels:
-      - 'inbox'
     ignore:
       - dependency-name: "circuitpython-stubs"


### PR DESCRIPTION
## Summary

The default labels that Dependabot adds to its PR are useful. Let's switch to them.

## Design

Remove the `labels` configuration entry.

## Screenshots or logs

PRs created by the bot for dependencies before Sep 2025 use the explicit `inbox` label. Afterward, the labels are `dependencies` and `github_actions`: https://github.com/wireddown/qt-py-s3-daq-app/pulls?q=is%3Apr+dependabot

## Testing

I tested this incidentally by not use `labels` for the GitHub Actions configuration

## Checklist

_~~Strike~~ inapplicable items_

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
