### PR TITLE
Pin poetry to v1.8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install poetry
       run: |
         echo '# :checkered_flag: Run Tests and Analyzers _(run ${{ github.run_number }} attempt ${{ github.run_attempt }})_' >> $env:GITHUB_STEP_SUMMARY
-        pipx install poetry
+        pipx install poetry==1.8.4
         poetry about
         poetry config --list
 


### PR DESCRIPTION
## Summary

This PR changes the CI to install poetry version 1.8.4, which is the current version used by `pyproject.toml`.

Without this pin, contributors see this message for `poetry install`

> Installing dependencies from lock file
> The lock file might not be compatible with the current version of Poetry.
> Upgrade Poetry to ensure the lock file is read properly or, alternatively, regenerate the lock file with the `poetry lock` command.

## Design

Use the exact recommended version.

## Screenshots or logs

See the logs from the PR checks.

## Testing

See the logs from the PR checks.

## Checklist

_~~Strike~~ inapplicable items_

- [x] ~~Issues linked / labels applied~~
- [x] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
