### PR TITLE
Data Viewer app: Increase CSV format compatibility

### DIFF
--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -18,6 +18,7 @@ from enum import StrEnum
 from tkinter import filedialog, font
 
 import matplotlib.figure as mpl_figure
+import numpy as np
 import pandas as pd
 import ttkbootstrap as ttk
 import ttkbootstrap.dialogs as ttk_dialogs
@@ -815,12 +816,20 @@ class DataViewer(guikit.AsyncWindow):
     def update_plot_axes(self) -> list[str]:
         """Reconfigure the plot for the new data and return the names of the measurement series."""
         time_coordinates, data_series = self.get_data()
-        for name, series in data_series.items():
+        for index, (name, series) in enumerate(data_series.items()):
+            needs_title = False
+            try:
+                float(name)  # pyright: ignore reportArgumentType -- we're type checking at run time
+                needs_title = True
+            except ValueError:
+                pass
+            # BUG: when needs_title is True, this code drops the first sample from each series
+            plot_name = f"Data series {index}" if needs_title else name
             measurements = series.tolist()
             self.plot_axes.plot(
                 time_coordinates,
                 measurements,
-                label=name,
+                label=plot_name,
             )
         self.plot_axes.set_xlabel("Time")
         self.plot_axes.set_ylabel("Measurement")
@@ -845,9 +854,17 @@ class DataViewer(guikit.AsyncWindow):
         # Assume table format, with time in first column and data in subsequent columns
         data_file_df = self.state.get_data()
         time_index = data_file_df[data_file_df.columns[0]]
-        time_coordinates = time_index.to_list()
-        series_names = data_file_df.columns[1:]
-        measurement_series = data_file_df[series_names]
+        time_dtypes = [float, int, np.dtypes.Float64DType, np.dtypes.Int64DType]
+        if type(time_index.dtype) not in time_dtypes:
+            time_stamps = pd.to_datetime(time_index)
+            first_time = time_stamps[0]
+            time_differences = time_stamps - first_time
+            time_coordinates = time_differences.dt.total_seconds() / 60
+            time_coordinates = time_coordinates.to_list()
+        else:
+            time_coordinates = time_index.to_list()
+
+        measurement_series = data_file_df[data_file_df.columns[1:]]
         return time_coordinates, measurement_series  # pyright: ignore reportReturnType
 
 

--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -864,7 +864,7 @@ class DataViewer(guikit.AsyncWindow):
         else:
             time_coordinates = time_index.to_list()
 
-        measurement_series = data_file_df[data_file_df.columns[1:]]
+        measurement_series = data_file_df[data_file_df.columns[1:]].select_dtypes(include=np.number)
         return time_coordinates, measurement_series  # pyright: ignore reportReturnType
 
 


### PR DESCRIPTION
## Summary

This PR allows the Data Viewer app to plot data from more types of CSV files. Previously, the app only succeeded when the first column was a numeric type, an example might be "relative time in minutes". Further, when the first row was data and not column titles, it used the first measurement as the plot labels.

With these updates
- the app plots data when the first column is a UTC timestamp string
- the app detects when columns do not have titles and uses a formatted name for the plot labels instead

## Design

- While getting the data from the app's state, detect the datatype of the first column and when the datatype isn't numerical, assume it is UTC timestamp.
- When plotting a data series, detect the datatype of the series' name and when it is numerical, generate a plot name.

## Screenshots or logs

There are no UI changes in this PR.

## Testing

### Untitled first column

```csv
,timestamp,relative_time_minutes,node_id,node_name,A0_average_code
0,2025-11-17 03:32:25.529165+00:00,0.0,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
1,2025-11-17 03:33:25.319700+00:00,0.9965089166666666,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
2,2025-11-17 03:34:25.132213+00:00,1.9933841333333333,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
3,2025-11-17 03:35:25.081628+00:00,2.99254105,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
4,2025-11-17 03:36:24.938612+00:00,3.99015745,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
5,2025-11-17 03:37:24.768080+00:00,4.98731525,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
6,2025-11-17 03:38:24.627224+00:00,5.98496765,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
7,2025-11-17 03:39:24.380807+00:00,6.9808607,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
8,2025-11-17 03:40:24.503705+00:00,7.982909,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
9,2025-11-17 03:41:24.337110+00:00,8.980132416666667,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
10,2025-11-17 03:42:24.250685+00:00,9.978692,node-42cea4d12c8b-0,node-42cea4d12c8b-0,0.0
```

### Untitled data

```csv
0.0,0.3917,0.1125,0.005681818181818181,71.21818181818182
0.0013462333333333332,0.384,0.1435,0.0072474747474747464,69.81818181818183
0.0018493666666666668,0.3837,0.1551,0.007833333333333333,69.76363636363637
0.0018826833333333334,0.3847,0.1559,0.007873737373737375,69.94545454545455
0.0019161833333333335,0.385,0.1566,0.007909090909090909,70.0
0.0019496333333333333,0.3941,0.1574,0.00794949494949495,71.65454545454546
0.001983,0.3847,0.1582,0.00798989898989899,69.94545454545455
```

### Titled columns with relative times

```csv
relative_time_minutes,power_watts,energy_w_s,energy_mAh,current_mA
0.0,0.1147,0.004,0.0002710027100271003,27.975609756097562
6.183333333333334e-05,0.0105,0.004,0.0002710027100271003,2.560975609756098
7.838333333333333e-05,0.0352,0.0041,0.0002777777777777779,8.585365853658537
0.00012225000000000002,0.0895,0.0043,0.00029132791327913285,21.82926829268293
0.00014491666666666665,0.087,0.0044,0.00029810298102981035,21.219512195121954
0.00017841666666666665,0.0858,0.0046,0.00031165311653116537,20.926829268292686
```

### Titled columns with UTC timestamps

```csv
time,power_watts,energy_w_s
2025-11-18 18:08:57.154685-08:00,0.2054,0.0645
2025-11-18 18:08:57.168566-08:00,0.2019,0.0673
2025-11-18 18:08:57.182809-08:00,0.2099,0.0703
2025-11-18 18:08:57.198081-08:00,0.2021,0.0734
2025-11-18 18:08:57.227807-08:00,0.2117,0.0797
2025-11-18 18:08:57.229799-08:00,0.2019,0.0801
2025-11-18 18:08:57.231800-08:00,0.2011,0.0805
2025-11-18 18:08:57.233810-08:00,0.2109,0.0809
```

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
