### PR TITLE
Host API: Add and use a factory method for localhost QTPyController

### DIFF
--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -4,9 +4,7 @@ import asyncio
 import importlib.resources
 import logging
 import pathlib
-import socket
 import tkinter as tk
-import uuid
 import webbrowser
 from enum import StrEnum
 from tkinter import font
@@ -444,12 +442,7 @@ class ScannerApp(guikit.AsyncWindow):
         self.message_input.delete(0, "end")
 
         async def send_message_and_get_response() -> tuple[str, str]:
-            controller = network.QTPyController(
-                broker_host="localhost",
-                group_id=qtpy_device.mqtt_group_id,
-                mac_address=f"{uuid.getnode():x}",
-                ip_address=socket.gethostbyname(socket.gethostname()),
-            )
+            controller = network.QTPyController.for_localhost_server(qtpy_device.mqtt_group_id)
             await controller.connect_and_subscribe()
             command_name = "custom"
             custom_parameters = {

--- a/src/qtpy_datalogger/network.py
+++ b/src/qtpy_datalogger/network.py
@@ -61,6 +61,20 @@ class NamedCounter:
 class QTPyController:
     """Class for controlling QT Py nodes."""
 
+    @staticmethod
+    def for_localhost_server(group_id: str) -> "QTPyController":
+        """Create a new QTPyController for the specified group_id that uses localhost for its MQTT server."""
+        broker_host = "localhost"
+        mac_address = f"{uuid.getnode():x}"
+        ip_address = socket.gethostbyname(socket.gethostname())
+        controller = QTPyController(
+            broker_host=broker_host,
+            group_id=group_id,
+            mac_address=mac_address,
+            ip_address=ip_address,
+        )
+        return controller
+
     def __init__(self, broker_host: str, group_id: str, mac_address: str, ip_address: str) -> None:
         """Return a QTPyController."""
         self.broker_host = broker_host
@@ -360,40 +374,21 @@ def open_session_on_node(group_id: str, node_id: str) -> None:
 
 async def query_nodes_from_mqtt_async(group_id: str) -> dict[str, dict[DetailKey, str]]:
     """Use a new QTPyController to scan the network for sensor_nodes."""
-    broker_host = "localhost"
-    mac_address = f"{uuid.getnode():x}"
-    ip_address = socket.gethostbyname(socket.gethostname())
-    controller = QTPyController(
-        broker_host=broker_host,
-        group_id=group_id,
-        mac_address=mac_address,
-        ip_address=ip_address,
-    )
-
+    controller = QTPyController.for_localhost_server(group_id)
     await controller.connect_and_subscribe()
     node_information = await controller.scan_for_nodes()
     await controller.disconnect()
-
     return node_information
 
 
 async def _open_session_on_node(group_id: str, node_id: str) -> None:
     """Use a new QTPyController to open a terminal session on the specified node_id."""
-    broker_host = "localhost"
-    mac_address = f"{uuid.getnode():x}"
-    ip_address = socket.gethostbyname(socket.gethostname())
-    controller = QTPyController(
-        broker_host=broker_host,
-        group_id=group_id,
-        mac_address=mac_address,
-        ip_address=ip_address,
-    )
-
     exit_commands = ["exit", "quit"]
     exit_options = "' or '".join(exit_commands)
     exit_help = f"Use any of '{exit_options}' to exit."
     print(exit_help)  # noqa: T201 -- use direct IO for user REPL
 
+    controller = QTPyController.for_localhost_server(group_id)
     await controller.connect_and_subscribe()
     while True:
         user_input = await asyncio.to_thread(input, f"{node_id} > ")


### PR DESCRIPTION
## Summary

This PR adds a common API for host-side apps that creates a QTPyController for a server running on `localhost`.

## Design

- Add a `staticmethod` to the QTPyController class
- Replace calls to the class constructor with calls to the new factory method

## Screenshots or logs

The host side can still detect and communicate with nodes.

**`poetry run qtpy-datalogger connect --node node-4f21afa56341-0`**
```
Use any of 'exit' or 'quit' to exit.
node-4f21afa56341-0 > hello
Received 'received: hello' from node with 54224 kB used, 2008496 kB remaining, at temperature 52.0 degC
node-4f21afa56341-0 > exit
```

## Testing

See log above

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
