### PR TITLE
Apps: Make apps runnable from multiprocessing

### DIFF
--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -868,6 +868,11 @@ class DataViewer(guikit.AsyncWindow):
         return time_coordinates, measurement_series  # pyright: ignore reportReturnType
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the app."""
     logger.debug(f"Launching {__package__}")
     asyncio.run(guikit.AsyncApp.create_and_run(DataViewer))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -520,6 +520,11 @@ class ScannerApp(guikit.AsyncWindow):
         self.message_log.mark_set("insert", index)
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the app."""
     logger.debug(f"Launching {__package__}")
     asyncio.run(guikit.AsyncApp.create_and_run(ScannerApp))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This change allows one app to launch another.

## Design

- Add a `main()` function to each app

## Screenshots or logs

See testing below

## Testing

```python
import multiprocessing
import qtpy_datalogger.apps.scanner

scanner_process = multiprocessing.Process(target=qtpy_datalogger.apps.scanner.main, name="QT Py Scanner")
scanner_process.start()
```

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
