### PR TITLE
server CLI app: Retain a subscription to the MQTT server's log topics

### DIFF
--- a/src/qtpy_datalogger/server.py
+++ b/src/qtpy_datalogger/server.py
@@ -120,6 +120,8 @@ def handle_server(behavior: Behavior, publish: tuple[str, str]) -> None:
             "$SYS/#",
             "--topic",
             f"{node_mqtt.get_domain()}/#",
+            "--topic",
+            "$SYS/broker/log/#",
             "-F",
             "%j",
         ]


### PR DESCRIPTION
## Summary

This PR changes the `qtpy-datalogger server --observe` CLI app to continue receiving messages on the `$SYS/broker/log` topic tree. This allows the CLI app to show client connections and disconnections, which can be helpful in analyzing the service and debugging node problems.

## Design

- Add a subscription for the log topic tree
  - Thankfully, the Eclipse Mosquitto Broker service uses the order of command line arguments to sequence subscriptions and unsubscriptions.

## Screenshots or logs

**`poetry run qtpy-datalogger server --observe`**
```
INFO     Eclipse Mosquitto MQTT v5/v3.1.1 broker
INFO            State  Running
INFO           Status  OK
INFO          Startup  Auto
INFO       Executable  C:\Program Files\mosquitto\mosquitto.exe
INFO           Server  Listening on port 1883
INFO         Firewall  Open on port 1883

INFO     Subscribing with 'C:\Program Files\mosquitto\mosquitto_sub.exe --id qtpy-datalogger-sub --topic $SYS/# --unsubscribe $SYS/# --topic qtpy/# --topic $SYS/broker/log/# -F %j'
INFO     Use Ctrl-C to quit
{"tst":"2026-04-12T18:11:19.472000-0700","topic":"$SYS/broker/version","qos":0,"retain":1,"payloadlen":24,"payload":"mosquitto version 2.0.21"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/uptime","qos":0,"retain":1,"payloadlen":13,"payload":"28413 seconds"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/total","qos":0,"retain":1,"payloadlen":1,"payload":"1"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/inactive","qos":0,"retain":1,"payloadlen":1,"payload":"0"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/disconnected","qos":0,"retain":1,"payloadlen":1,"payload":"0"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/active","qos":0,"retain":1,"payloadlen":1,"payload":"1"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/connected","qos":0,"retain":1,"payloadlen":1,"payload":"1"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/expired","qos":0,"retain":1,"payloadlen":1,"payload":"0"}
{"tst":"2026-04-12T18:11:19.473000-0700","topic":"$SYS/broker/clients/maximum","qos":0,"retain":1,"payloadlen":1,"payload":"1"}

<snip>

{"tst":"2026-04-12T18:11:19.475000-0700","topic":"$SYS/broker/bytes/sent","qos":0,"retain":1,"payloadlen":4,"payload":"8839"}
{"tst":"2026-04-12T18:11:19.475000-0700","topic":"$SYS/broker/log/M/subscribe","qos":0,"retain":0,"payloadlen":40,"payload":"1776042679: qtpy-datalogger-sub 0 $SYS/#"}
{"tst":"2026-04-12T18:11:19.475000-0700","topic":"$SYS/broker/log/M/subscribe","qos":0,"retain":0,"payloadlen":40,"payload":"1776042679: qtpy-datalogger-sub 0 qtpy/#"}
{"tst":"2026-04-12T18:11:19.475000-0700","topic":"$SYS/broker/log/M/subscribe","qos":0,"retain":0,"payloadlen":51,"payload":"1776042679: qtpy-datalogger-sub 0 $SYS/broker/log/#"}
{"tst":"2026-04-12T18:11:19.475000-0700","topic":"$SYS/broker/log/M/unsubscribe","qos":0,"retain":0,"payloadlen":38,"payload":"1776042679: qtpy-datalogger-sub $SYS/#"}
```

## Testing

See log above.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
