### PR TITLE
Communication API: Add methods to post and clear a retained message

### DIFF
--- a/src/qtpy_datalogger/network.py
+++ b/src/qtpy_datalogger/network.py
@@ -218,7 +218,7 @@ class QTPyController:
                     payload = node_classes.ActionPayload.from_dict(response)
                     sending_node = node_mqtt.node_from_topic(payload.sender.descriptor_topic)
                     result_id = payload.action.message_id
-                    if sending_node == node_id and result_id == action_id:
+                    if node_id in (sending_node, "+") and result_id == action_id:
                         logger.debug(f"Matched result '{payload.action.parameters}'")
                         parameters_and_sender = (payload.action.parameters, payload.sender)
                     else:
@@ -229,6 +229,18 @@ class QTPyController:
         for other_message in other_messages:
             self._requeue_or_discard(other_message)
         return parameters_and_sender
+
+    def post_retained_group_action(self, action: node_classes.ActionInformation) -> None:
+        """Publish an action to the group's broadcast topic and retain it."""
+        action_payload = node_classes.ActionPayload(
+            action=action,
+            sender=_build_sender_information(self.descriptor_topic),
+        )
+        self.client.publish(self.broadcast_topic, json.dumps(action_payload.as_dict()), retain=True)
+
+    def clear_retained_group_action(self) -> None:
+        """Remove the retained action on the group's broadcast topic."""
+        self.client.publish(self.broadcast_topic, "", retain=True)
 
     async def disconnect(self) -> None:
         """Disconnect from the MQTT broker."""


### PR DESCRIPTION
## Summary

This PR adds the ability for the host to post and clear retained messages for nodes. When nodes subscribe to a topic or topic tree, the message broker sends any retained messages that match their subscriptions.

One use case for this is sleeping nodes -- when a node wakes and subscribes to its command topic, the broker automatically sends any retained messages from the host. Without a retained message, a host-side app must monitor for new connections from nodes and then send a command to each that connects.

## Design

- Add methods to QTPyController
  - `post_retained_group_action()`
  - `clear_retained_group_action()`
- When host-side apps do not know which or how many nodes may respond to a retained message, allow them to use `node_id="+"` when calling `QTPyController.get_matching_result()` to match any node's response.

## Screenshots or logs

See testing below.

## Testing

- Observe broker messages with `qtpy-datalogger server --observe`
- Create a QTPyController and post a retained message
- Notice `"retain":1` in the broker's log

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
