### PR TITLE
equip CLI app: Copy new files with --newer-files-only

### DIFF
--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -314,7 +314,7 @@ def _equip_snsr_node(behavior: Behavior, comparison_information: dict[str, SnsrN
             full_path = this_bundle.device_files[0].joinpath(path)
             if not full_path.is_file():
                 continue
-            if freshness == "newer":
+            if freshness == "newer" and all(pattern not in str(path) for pattern in ignore_patterns):
                 logger.info(f"  Newer: {path}")
                 newer_files.add(path.name)
                 continue
@@ -422,6 +422,8 @@ def _compare_file_trees(tree1: list[pathlib.Path], tree2: list[pathlib.Path]) ->
         if modification_time1 < modification_time2:
             age = "older"
         tree1_file_ages[path] = age
+    for path in set1 - set2:
+        tree1_file_ages[path] = "newer"
     return tree1_file_ages
 
 

--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -19,7 +19,7 @@ import toml
 
 from qtpy_datalogger import discovery
 
-from .datatypes import ConnectionTransport, Default, ExitCode, Links, SnsrNotice, SnsrPath, suppress_unless_debug
+from .datatypes import ConnectionTransport, Default, ExitCode, Links, SnsrNotice, SnsrPath
 
 logger = logging.getLogger(__name__)
 
@@ -499,9 +499,14 @@ def _query_modules_from_circup(main_folder: pathlib.Path, log_info: bool) -> lis
     """Use circup to detect the installed CircuitPython modules and versions found in the specified folder."""
     if main_folder.joinpath("lib").exists() and (log_info or logger.isEnabledFor(logging.DEBUG)):
         logger.info("Detecting installed external CircuitPython modules")
-    with suppress_unless_debug():
-        circup_backend = circup.DiskBackend(str(main_folder), logger)
-        installed_cp_modules = circup_backend.get_device_versions()
+
+    circup_logger = logger
+    if not logger.isEnabledFor(logging.DEBUG):
+        muted_logger = logging.getLogger("muted")
+        muted_logger.setLevel(logging.CRITICAL)
+        circup_logger = muted_logger
+    circup_backend = circup.DiskBackend(str(main_folder), circup_logger)
+    installed_cp_modules = circup_backend.get_device_versions()
     if installed_cp_modules and (log_info or logger.isEnabledFor(logging.DEBUG)):
         _ = [
             logger.info(f" * {name:<20} {details['__version__']}")

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -185,7 +185,7 @@ def test_only_newer_files(
 ) -> None:
     """Does it skip circup packages for Behavior.OnlyNewerFiles?"""
     create_test_device_folder(tmp_path)
-    newer_files = []
+    newer_files: list[pathlib.Path] = []
 
     def override_file_freshness(
         tree1: list[pathlib.Path], tree2: list[pathlib.Path], newer_files: list[pathlib.Path] = newer_files
@@ -197,12 +197,16 @@ def test_only_newer_files(
         equal_file = shared_in_both[0]
         older_file = shared_in_both[1]
         newer_file = shared_in_both[2]
+        novel_file = tree1[0] / "PYTEST_NEWFILE.py"
+        novel_file.touch()
         tree1_file_ages = {
             equal_file: "equal",
             older_file: "older",
             newer_file: "newer",
+            novel_file: "newer",
         }
         newer_files.append(newer_file)
+        newer_files.append(novel_file)
         return tree1_file_ages
 
     monkeypatch.setattr(equip, "_compare_file_trees", override_file_freshness)
@@ -214,4 +218,7 @@ def test_only_newer_files(
     assert_device_matches_self(comparison_results)
     assert not tmp_path.joinpath("lib").exists()
     updated_file = newer_files[0]
+    copied_file = newer_files[1]
+    copied_file.unlink()
     assert f"Newer: {updated_file!s}" in caplog.text
+    assert f"Newer: {copied_file!s}" in caplog.text


### PR DESCRIPTION
## Summary

This PR changes the behavior of `qtpy-datalogger equip --newer-files-only` to copy _new_ files onto the node. Previously, the operation would only _update_ files that _already existed_ on the node and not add new files.

## Design

- Mark every file that only appears on the host side as `newer` so that `--newer-files-only` copies it to the node
- Skip copying newer files in the ignore list
- Use a `CRITICAL` level logger for `circup.DiskBackend` operations because, after the version upgrade, it buffers emitting its messages and the suppression does not hide them

## Screenshots or logs

**`git status -s`**
```
?? src/qtpy_datalogger/sensor_node/snsr/NEWFILE.py
```

**`qtpy-datalogger equip --newer-files-only`**
```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group 'zone1'
INFO     Identifying QT Py devices
INFO     Auto-selected 'Adafruit QT Py ESP32-S3 2MB PSRAM' as port 'COM4' on 'F:\'
INFO     Probing for sensor_node at 'F:\'
INFO      - version    0.1.0.post0.dev0
INFO      - timestamp  2025.06.06  20:39:10
INFO     Found 21 total module references   * external   . builtin   ~ internal
INFO      * adafruit_adxl37x
INFO      * adafruit_connection_manager
INFO      * adafruit_minimqtt
INFO      . analogio
INFO      . board
INFO      . busio
INFO      . collections
INFO      . gc
INFO      . json
INFO      . microcontroller
INFO      . os
INFO      . struct
INFO      . sys
INFO      . time
INFO      . usb_cdc
INFO      . wifi
INFO      ~ echo
INFO      ~ linebuffer
INFO      ~ py_shell
INFO      ~ snsr
INFO      ~ soil_swell
INFO     Detecting installed external CircuitPython modules
INFO      * adafruit_adxl34x     1.12.16
INFO      * adafruit_adxl37x     1.2.3
INFO      * adafruit_bus_device  5.2.12
INFO      * adafruit_connection_manager 3.1.4
INFO      * adafruit_minimqtt    8.0.1
INFO      * adafruit_ticks       1.1.3
INFO     Forcing installation of newer files
INFO     Installing sensor_node v0.1.0.post0.dev0 to 'F:\'
INFO       Newer: snsr\NEWFILE.py
INFO     Bundle files updated
```

## Testing

- Update `test_only_newer_files()` to validate that `equip --newer-files-only` copies novel files to the node

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
