### PR TITLE
Host API: Add ThemeChanger for the matplotlib GUI elements

### DIFF
--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -73,7 +73,7 @@ class AppState:
         if new_value == self._theme_name:
             return
         self._theme_name = new_value
-        ttk.Style().theme_use(new_value)
+        guikit.ThemeChanger.use_bootstrap_theme(new_value, self._tk_notifier)
 
     @property
     def data_file(self) -> pathlib.Path:
@@ -363,9 +363,6 @@ class DataViewer(guikit.AsyncWindow):
         toolbar_frame = ttkbootstrap_matplotlib.create_styled_plot_toolbar(toolbar_row, self.canvas_figure)
         toolbar_frame.grid(column=1, row=0, sticky=(tk.EW, tk.N), padx=(8, 0))  # pyright: ignore reportArgumentType -- the type hint for library uses strings
 
-        # matplotlib elements must be created before setting the theme or the button icons initialize with poor color contrast
-        self.state.active_theme = "flatly"
-
         self.canvas_cover = ttk.Frame(main, name="canvas_cover", style=bootstyle.LIGHT)
         self.canvas_cover.grid(column=0, row=0, sticky=tk.NSEW)
         self.canvas_cover.columnconfigure(0, weight=1)
@@ -398,20 +395,14 @@ class DataViewer(guikit.AsyncWindow):
         demo_button.grid(column=0, row=2, sticky=tk.N, pady=(0, 16))
         demo_button.configure(command=functools.partial(self.open_demo, demo_button))
 
-        self.root_window.bind(
-            AppState.Event.DataFileChanged,
-            self.on_data_file_changed,
-        )
-        self.root_window.bind(
-            AppState.Event.ReplayActiveChanged,
-            self.on_replay_active_changed,
-        )
-        self.root_window.bind(
-            "<<ThemeChanged>>",
-            self.on_theme_changed,
-        )
+        self.root_window.bind(AppState.Event.DataFileChanged, self.on_data_file_changed)
+        self.root_window.bind(AppState.Event.ReplayActiveChanged, self.on_replay_active_changed)
+        guikit.ThemeChanger.add_handler(self.root_window, self.on_theme_changed)
 
         self.reload_file(sender=main)
+
+        # matplotlib elements must be created before setting the theme or the button icons initialize with poor color contrast
+        self.state.active_theme = "flatly"
 
     def build_window_menu(self) -> None:
         """Create the entries for the window menu bar."""

--- a/src/qtpy_datalogger/apps/matplotlib_demo.py
+++ b/src/qtpy_datalogger/apps/matplotlib_demo.py
@@ -117,14 +117,12 @@ class PlottingApp(guikit.AsyncWindow):
         toolbar_frame = ttkbootstrap_matplotlib.create_styled_plot_toolbar(toolbar_row, self.canvas)
         toolbar_frame.grid(column=1, row=0, sticky=tk.EW)
 
-    def on_show(self) -> None:
-        """Initialize UI before entering main loop."""
         theme_name = "cosmo"
         style = ttk.Style.get_instance()
         if not style:
             raise ValueError()
         self.theme_combobox.set(theme_name.capitalize())
-        style.theme_use(theme_name)
+        guikit.ThemeChanger.use_bootstrap_theme(theme_name, self.root_window)
 
     async def on_loop(self) -> None:
         """Update the UI with new information."""

--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -84,9 +84,7 @@ class ScannerApp(guikit.AsyncWindow):
         self.svg_images = {}
 
         # Theme
-        style = ttk.Style()
-        style.theme_use("cosmo")
-        colors = style.colors
+        guikit.ThemeChanger.use_bootstrap_theme("cosmo", self.root_window)
 
         # Window title bar
         package = importlib.resources.files(qtpy_datalogger)
@@ -163,7 +161,7 @@ class ScannerApp(guikit.AsyncWindow):
             results_frame,
             coldata=result_columns,
             height=9,  # Unit is lines of text
-            stripecolor=(colors.light, None),  # pyright: ignore reportAttributeAccessIssue -- the type hint for bootstrap omits its own additions
+            stripecolor=(guikit.hex_string_for_style(bootstyle.LIGHT), None),  # pyright: ignore reportAttributeAccessIssue -- the type hint for bootstrap omits its own additions
         )
         self.scan_results_table.view.configure(selectmode=tk.BROWSE)
         self.scan_results_table.view.bind("<<TreeviewSelect>>", self.on_row_selected)

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -1,8 +1,10 @@
 """Shared classes and helpers for creating GUIs."""
 
 import asyncio
+import enum
 import logging
 import tkinter as tk
+from collections.abc import Callable
 
 import ttkbootstrap as ttk
 import ttkbootstrap.icons as ttk_icons
@@ -103,6 +105,28 @@ class AsyncWindow:
     def exit(self) -> None:
         """Close the UI and exit."""
         self.should_run_loop = False
+
+
+class ThemeChanger:
+    """A class that changes Tk themes and emits a corresponding event."""
+
+    class Event(enum.StrEnum):
+        """An enumeration of events emitted by this class."""
+
+        BootstrapThemeChanged = "<<BootstrapThemeChanged>>"
+
+    @staticmethod
+    def add_handler(owner: tk.Misc, command: Callable[[tk.Event], None]) -> str:
+        """Subscribe command as a handler for the BootstrapThemeChanged event and return a unique ID for the binding."""
+        # **Must** bind to the root window, emit to the root window, add to the handler list
+        # - See https://stackoverflow.com/a/31798918
+        return owner.winfo_toplevel().bind(ThemeChanger.Event.BootstrapThemeChanged, command, add="+")
+
+    @staticmethod
+    def use_bootstrap_theme(new_theme: str, owner: tk.Misc) -> None:
+        """Change the ttkbootstrap theme and notify BootstrapThemeChanged subscribers."""
+        ttk.Style().theme_use(new_theme)
+        owner.winfo_toplevel().event_generate(ThemeChanger.Event.BootstrapThemeChanged)
 
 
 class DemoWithAnimation(AsyncWindow):
@@ -232,12 +256,9 @@ def create_theme_combobox(parent: tk.BaseWidget) -> ttk.Combobox:
         if not isinstance(sending_combobox, ttk.Combobox):
             raise TypeError()
         theme_name = sending_combobox.get().lower()
-        style = ttk.Style.get_instance()
-        if not style:
-            raise ValueError()
         sending_combobox.configure(state=bootstyle.READONLY)
         sending_combobox.selection_clear()
-        style.theme_use(theme_name)
+        ThemeChanger.use_bootstrap_theme(theme_name, sending_combobox)
 
     theme_combobox.bind("<<ComboboxSelected>>", handle_change_theme)
     return theme_combobox

--- a/src/qtpy_datalogger/ttkbootstrap_matplotlib.py
+++ b/src/qtpy_datalogger/ttkbootstrap_matplotlib.py
@@ -1,5 +1,6 @@
 """Functions for applying ttkbootstrap styling to matplotlib visuals."""
 
+import functools
 import logging
 import tkinter as tk
 from enum import StrEnum
@@ -16,6 +17,8 @@ from matplotlib.backends.backend_tkagg import (
 from matplotlib.figure import Figure
 from matplotlib.legend import Legend
 from ttkbootstrap import constants as bootstyle
+
+from qtpy_datalogger.guikit import ThemeChanger
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +43,12 @@ def create_styled_plot_canvas(
     figure: Figure,
     canvas_frame: ttk.Frame,
 ) -> FigureCanvasTkAgg:
-    """Return a FigureCanvasTkAgg from matplotlib that responds to the ttkbootstrap '<<ThemeChanged>>' event."""
+    """Return a FigureCanvasTkAgg from matplotlib that responds to guikit.ThemeChanger.Event.BootstrapThemeChanged."""
     canvas = FigureCanvasTkAgg(figure, canvas_frame)
-    setattr(canvas.get_tk_widget(), ReservedName.EmbeddedFigure, canvas)
-    canvas.get_tk_widget().grid(column=0, row=0, sticky=tk.NSEW)
-    canvas.get_tk_widget().bind("<Expose>", handle_theme_changed)
-    canvas.get_tk_widget().bind("<<ThemeChanged>>", handle_theme_changed)
+    canvas_widget = canvas.get_tk_widget()
+    setattr(canvas_widget, ReservedName.EmbeddedFigure, canvas)
+    canvas_widget.grid(column=0, row=0, sticky=tk.NSEW)
+    ThemeChanger.add_handler(canvas_frame, functools.partial(handle_theme_changed, canvas_widget))
     return canvas
 
 
@@ -56,7 +59,7 @@ def create_styled_plot_toolbar(
     toolbar_width: int = 500,
     border_thickness: int = 3,
 ) -> tk.Frame:
-    """Return a tk.Frame that contains a NavigationToolbar from matplotlib and responds to the ttkbootstrap '<<ThemeChanged>>' event."""
+    """Return a tk.Frame that contains a NavigationToolbar from matplotlib and responds to guikit.ThemeChanger.Event.BootstrapThemeChanged."""
     canvas_aspect = matching_canvas.get_width_height()
     toolbar_width = max(toolbar_width, canvas_aspect[0])  # Any narrower and the updates flicker
     toolbar_height = 50  # Any shorter and the updates flicker
@@ -67,8 +70,7 @@ def create_styled_plot_toolbar(
     toolbar_border.columnconfigure(0, weight=0, minsize=final_width)
     toolbar_border.rowconfigure(0, weight=0, minsize=final_height)
     toolbar_border.grid_propagate(False)  # Lock the height and width by ignoring child size requests
-    toolbar_border.bind("<Expose>", handle_theme_changed)
-    toolbar_border.bind("<<ThemeChanged>>", handle_theme_changed)
+    ThemeChanger.add_handler(toolbar_border, functools.partial(handle_theme_changed, toolbar_border))
 
     toolbar_frame = tk.Frame(toolbar_border, name="toolbar_frame")
     toolbar_frame.grid(column=0, row=0)
@@ -93,19 +95,18 @@ def create_styled_plot_toolbar(
     return toolbar_border
 
 
-def handle_theme_changed(event_args: tk.Event) -> None:
-    """Handle the ttkbootstrap virtual event named <<ThemeChanged>>."""
-    sender = event_args.widget
+def handle_theme_changed(themed_widget: tk.Misc, event_args: tk.Event) -> None:
+    """Handle the virtual event ThemeChanger.Event.BootstrapThemeChanged."""
     style = ttk.Style.get_instance()
     if not (style and style.theme):
         raise ValueError()
 
     default_theme = ttk_themes.STANDARD_THEMES[bootstyle.DEFAULT_THEME]
     requested_theme = ttk_themes.STANDARD_THEMES.get(style.theme.name, default_theme)
-    if isinstance(sender, tk.Canvas):
-        apply_figure_style(sender, requested_theme)
-    elif isinstance(sender, tk.Frame):
-        apply_toolbar_style(sender, requested_theme)
+    if isinstance(themed_widget, tk.Canvas):
+        apply_figure_style(themed_widget, requested_theme)
+    elif isinstance(themed_widget, tk.Frame):
+        apply_toolbar_style(themed_widget, requested_theme)
     else:
         raise TypeError()
 


### PR DESCRIPTION
## Summary

This PR fixes a lag problem with mouse interaction in the package's apps, and introduces a new host API for handling theme changes.

### Details

The Tkinter backend for `matplotlib` does not use Themed Tkinter widgets. Consequently, when the theme changes at run time, the graph and controls do not respond automatically. The `ttkbootstrap_matplotlib` submodule in this package has some code that adds styling support for these GUI elements and responds to events, including the ttkbootstrap `<<ThemeChanged>>` virtual event.

Tkinter's virtual events require the receiver to bind to the sender. However, `ttkbootstrap_matplotlib` does not do this and instead binds the virtual event to the Tk elements, which will never send a `<<ThemeChanged>>` event by design. Only newly constructed widgets have the correct theme.

The submodule also binds the  `<Expose>` event to help compensate for ignored theme changes. Unfortunately, the `<Expose>` event fires for **every** UI appearance change, not just a new ttk theme. This causes the custom handlers that redraw the figures, menus, and svg icons to execute for unrelated things like a dynamic button style change on mouse-enter or mouse-leave.

## Design

- Add a new class named `ThemeChanger` that defines a virtual event and methods to add an event handler and change the theme.
  - Use `winfo_toplevel()` to guarantee that all bindings and emissions use the same root Tk instance
  - Use `add="+"` when binding because there are at least two listeners to the event: the graph and controls
- In `ttkbootstrap_matplotlib`, remove the `<Expose>` binding and replace the `<<ThemeChanged>>` binding with the new `ThemeChanger` class
- Use the new `ThemeChanger` in the apps

## Screenshots or logs

No visual changes, only performance improvements.

## Testing

The apps still respond to theme changes, and now they don't lag with mouse interaction.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
