### PR TITLE
Host API: Add AboutDialog class to guikit

### DIFF
--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -113,134 +113,6 @@ class AppState:
         return self.data_file_df.copy()
 
 
-class AboutDialog(ttk_dialogs.Dialog):
-    """A class that presents information about the app."""
-
-    def __init__(self, parent: ttk.Window, title: str = "") -> None:
-        """Initialize a new AboutDialog instance."""
-        super().__init__(parent, title, alert=False)
-
-    def create_body(self, master: tk.Misc) -> None:  # noqa: PLR0915 -- allow long function to create the UI
-        """Create the UI for the dialog."""
-        master.columnconfigure(0, weight=1)
-        master.rowconfigure(0, weight=1)
-        self.main_frame = ttk.Frame(master, padding=16)
-        self.main_frame.grid(column=0, row=0, sticky=tk.NSEW)
-        self.main_frame.columnconfigure(0, weight=1)
-        self.main_frame.rowconfigure(0, weight=1)
-
-        message_frame = ttk.Frame(self.main_frame)
-        message_frame.grid(column=0, row=0, sticky=tk.NSEW)
-        message_frame.columnconfigure(0, weight=0, minsize=40)  # Filler
-        message_frame.columnconfigure(1, weight=0)  # Icon1
-        message_frame.columnconfigure(2, weight=0)  # Icon2
-        message_frame.columnconfigure(3, weight=0)  # Icon3
-        message_frame.columnconfigure(4, weight=0, minsize=20)  # Filler
-        message_frame.columnconfigure(5, weight=0)  # Text
-        message_frame.columnconfigure(6, weight=0, minsize=40)  # Filler
-        message_frame.rowconfigure(0, weight=0, minsize=20)  # Filler
-        message_frame.rowconfigure(1, weight=0)  # Icons and Name
-        message_frame.rowconfigure(2, weight=0)  # Icons and Version
-        message_frame.rowconfigure(3, weight=0)  # Separator
-        message_frame.rowconfigure(4, weight=0)  # Help
-        message_frame.rowconfigure(5, weight=0)  # Source
-        message_frame.rowconfigure(6, weight=0)  # Source2
-        message_frame.rowconfigure(7, weight=0, minsize=50)  # Filler
-
-        icon_height = 48
-        icon_color = guikit.hex_string_for_style(StyleKey.Fg)
-        self.microchip_icon = icon_to_image("microchip", fill=icon_color, scale_to_height=icon_height)
-        microchip_label = ttk.Label(message_frame, image=self.microchip_icon, padding=3)
-        microchip_label.grid(column=1, row=1, rowspan=2)
-        self.qtpy_icon = icon_to_image("worm", fill=icon_color, scale_to_height=icon_height)
-        qtpy_label = ttk.Label(message_frame, image=self.qtpy_icon, padding=4)
-        qtpy_label.grid(column=2, row=1, rowspan=2)
-        self.chart_icon = icon_to_image("chart-line", fill=icon_color, scale_to_height=icon_height)
-        chart_label = ttk.Label(message_frame, image=self.chart_icon, padding=4)
-        chart_label.grid(column=3, row=1, rowspan=2, padx=(2, 0))
-
-        name_label = ttk.Label(message_frame, font=font.Font(weight="bold", size=28), text=DataViewer.app_name)
-        name_label.grid(column=5, row=1, sticky=tk.W)
-        self.notice_information = datatypes.SnsrNotice.get_package_notice_info(allow_dev_version=True)
-        bullet = ttk_icons.Emoji.get("black medium small square")
-        version_label = ttk.Label(
-            message_frame,
-            text=f"{self.notice_information.version} {bullet} {self.notice_information.timestamp:%Y-%m-%d} {bullet} {self.notice_information.commit}",
-        )
-        version_label.grid(column=5, row=2, sticky=tk.W, padx=(4, 0))
-        separator = ttk.Separator(message_frame)
-        separator.grid(column=1, row=3, columnspan=5, sticky=tk.EW, pady=4)
-        button_text_color = guikit.hex_string_for_style(StyleKey.SelectFg)
-        spacer = "   "
-        self.help_icon = icon_to_image("parachute-box", fill=button_text_color, scale_to_width=16)
-        help_button = ttk.Button(
-            message_frame,
-            compound=tk.LEFT,
-            image=self.help_icon,
-            text=f"{spacer}Online help ",  # The trailing space helps with internal margins
-            style=bootstyle.INFO,
-            width=18,
-            command=functools.partial(webbrowser.open_new_tab, datatypes.Links.Homepage),
-        )
-        help_button.grid(column=5, row=4, sticky=tk.W, pady=(18, 0))
-        self.source_icon = icon_to_image("github-alt", fill=button_text_color, scale_to_width=16)
-        source_button = ttk.Button(
-            message_frame,
-            compound=tk.LEFT,
-            image=self.source_icon,
-            text=f"{spacer}Source code",
-            style=bootstyle.INFO,
-            width=18,
-            command=functools.partial(webbrowser.open_new_tab, datatypes.Links.Source),
-        )
-        source_button.grid(column=5, row=5, sticky=tk.W, pady=(22, 0))
-
-    def create_buttonbox(self, master: tk.Misc) -> None:
-        """Create the bottom row of buttons."""
-        if not self._toplevel:
-            raise RuntimeError()
-        self.main_frame.rowconfigure(1, weight=1)
-
-        button_frame = ttk.Frame(self.main_frame)
-        button_frame.grid(column=0, row=1, sticky=tk.NSEW, padx=(0, 16), pady=(8, 0))
-        button_frame.columnconfigure(0, weight=1)
-        button_frame.columnconfigure(1, weight=0)
-        button_frame.rowconfigure(0, weight=0)
-        self.copy_version_button = ttk.Button(
-            button_frame,
-            text=DataViewer.CommandName.CopyVersion,
-            style=bootstyle.OUTLINE,
-            command=self.copy_version,
-            width=12,
-        )
-        self.copy_version_button.grid(column=0, row=0, sticky=tk.E, padx=(0, 16))
-        ok_button = ttk.Button(button_frame, text=DataViewer.CommandName.OK, command=self._toplevel.destroy)
-        ok_button.grid(column=1, row=0, sticky=tk.E)
-        self._initial_focus = ok_button
-
-    def copy_version(self) -> None:
-        """Copy the version information to the clipboard."""
-        if not self._toplevel:
-            raise RuntimeError()
-        formatted_version = {
-            "version": self.notice_information.version,
-            "timestamp": str(self.notice_information.timestamp),
-            "commit": self.notice_information.commit,
-        }
-        self._toplevel.clipboard_clear()
-        self._toplevel.clipboard_append(json.dumps(formatted_version))
-        status_emoji = ttk_icons.Emoji.get("white heavy check mark")
-        self.copy_version_button.configure(text=f"{status_emoji}   Copied!", bootstyle=bootstyle.SUCCESS)
-        self.copy_version_button.after(
-            850,
-            functools.partial(
-                self.copy_version_button.configure,
-                text=DataViewer.CommandName.CopyVersion,
-                bootstyle=(bootstyle.DEFAULT, bootstyle.OUTLINE),
-            ),
-        )
-
-
 class DataViewer(guikit.AsyncWindow):
     """A GUI that loads a CSV data file and plots the columns."""
 
@@ -673,8 +545,8 @@ class DataViewer(guikit.AsyncWindow):
 
     def show_about(self) -> None:
         """Handle the Help::About menu command."""
-        about_dialog = AboutDialog(parent=self.root_window, title=f"About {DataViewer.app_name}")
-        about_dialog.show()
+        about_dialog = guikit.AboutDialog(parent=self.root_window, app_name=DataViewer.app_name)
+        guikit.AboutDialog.show_no_wait(about_dialog, guikit.DialogBehavior.Modeless)
 
     def on_data_file_changed(self, event_args: tk.Event) -> None:
         """Handle the DataFileChanged event."""

--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -4,7 +4,6 @@ import asyncio
 import atexit
 import contextlib
 import functools
-import json
 import logging
 import math
 import pathlib
@@ -13,7 +12,6 @@ import shutil
 import tempfile
 import time
 import tkinter as tk
-import webbrowser
 from enum import StrEnum
 from tkinter import filedialog, font
 
@@ -21,13 +19,11 @@ import matplotlib.figure as mpl_figure
 import numpy as np
 import pandas as pd
 import ttkbootstrap as ttk
-import ttkbootstrap.dialogs as ttk_dialogs
-import ttkbootstrap.icons as ttk_icons
 import ttkbootstrap.themes.standard as ttk_themes
 from tkfontawesome import icon_to_image
 from ttkbootstrap import constants as bootstyle
 
-from qtpy_datalogger import datatypes, guikit, ttkbootstrap_matplotlib
+from qtpy_datalogger import guikit, ttkbootstrap_matplotlib
 
 logger = logging.getLogger(pathlib.Path(__file__).stem)
 
@@ -748,7 +744,7 @@ class DataViewer(guikit.AsyncWindow):
         self.replay_variable.set(replay_active)
 
     def on_theme_changed(self, event_args: tk.Event) -> None:
-        """Handle the ThemeChanged event."""
+        """Handle the ThemeChanger.Event.BootstrapThemeChanged event."""
         theme_name = self.state.active_theme
         self.theme_variable.set(theme_name.capitalize())
         self.startup_label.configure(background=guikit.hex_string_for_style(bootstyle.LIGHT))

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -9,6 +9,7 @@ import tkinter as tk
 import webbrowser
 from collections.abc import Callable
 from tkinter import font
+from typing import ClassVar
 
 import ttkbootstrap as ttk
 import ttkbootstrap.icons as ttk_icons
@@ -102,6 +103,23 @@ class AsyncDialog:
     Helper methods
     - self.exit()
     """
+
+    _open_dialogs: ClassVar[set["AsyncDialog"]] = set()
+    _open_dialog_tasks: ClassVar[set[asyncio.Task]] = set()
+
+    @classmethod
+    def show_no_wait(cls, dialog: "AsyncDialog", behavior: DialogBehavior) -> None:
+        """Show the dialog without waiting for or returning a result."""
+        if dialog not in cls._open_dialogs:
+
+            def finalize_safe_show(task: asyncio.Task) -> None:
+                cls._open_dialogs.discard(dialog)
+                cls._open_dialog_tasks.discard(task)
+
+            open_dialog_task = asyncio.create_task(dialog.show(behavior))
+            open_dialog_task.add_done_callback(finalize_safe_show)
+            cls._open_dialogs.add(dialog)
+            cls._open_dialog_tasks.add(open_dialog_task)
 
     def __init__(self, parent: ttk.Toplevel | ttk.Window, title: str) -> None:
         """Initialize a new Tk Toplevel and cache the asyncio event loop."""
@@ -255,6 +273,7 @@ class AboutDialog(AsyncDialog):
         if not all_icons:
             all_icons = ["microchip", "worm", app_icon]
         self.app_icons = all_icons[:3]
+        self.icon_labels = []
         self.app_icon_images = []
         self.help_url = help_url or datatypes.Links.Homepage
         self.source_url = source_url or datatypes.Links.Source
@@ -290,15 +309,13 @@ class AboutDialog(AsyncDialog):
         message_frame.rowconfigure(6, weight=0)  # Source2
         message_frame.rowconfigure(7, weight=0, minsize=50)  # Filler
 
-        icon_height = 48
-        icon_color = hex_string_for_style(StyleKey.Fg)
-        icon_column = 3
-        for icon_name in reversed(self.app_icons):
-            icon_image = icon_to_image(icon_name, fill=icon_color, scale_to_height=icon_height)
-            self.app_icon_images.append(icon_image)
-            chart_label = ttk.Label(message_frame, image=icon_image, padding=4)
-            chart_label.grid(column=icon_column, row=1, rowspan=2)
-            icon_column = icon_column - 1
+        for index, _ in enumerate(self.app_icons):
+            icon_column = index + 1  # Column 0 is margin filler
+            icon_label = ttk.Label(message_frame, padding=4)
+            icon_label.grid(column=icon_column, row=1, rowspan=2)
+            self.icon_labels.append(icon_label)
+
+        self.refresh_icons()
 
         name_label = ttk.Label(message_frame, font=font.Font(weight="bold", size=28), text=self.app_name)
         name_label.grid(column=5, row=1, sticky=tk.W)
@@ -353,6 +370,18 @@ class AboutDialog(AsyncDialog):
         ok_button.grid(column=1, row=0, sticky=tk.E)
         self.initial_focus = ok_button
 
+        ThemeChanger.add_handler(self.root_window, self.on_theme_changed)
+
+    def refresh_icons(self) -> None:
+        """Refresh the icons in the dialog using the active style."""
+        icon_height = 48
+        icon_color = hex_string_for_style(StyleKey.Fg)
+        self.app_icon_images.clear()
+        for icon_name, icon_label in zip(self.app_icons, self.icon_labels, strict=True):
+            icon_image = icon_to_image(icon_name, fill=icon_color, scale_to_height=icon_height)
+            self.app_icon_images.append(icon_image)
+            icon_label.configure(image=icon_image)
+
     def copy_version(self) -> None:
         """Copy the version information to the clipboard."""
         formatted_version = {
@@ -376,6 +405,10 @@ class AboutDialog(AsyncDialog):
     async def on_loop(self) -> None:
         """Update UI elements."""
         await asyncio.sleep(20e-3)
+
+    def on_theme_changed(self, event_args: tk.Event) -> None:
+        """Handle the ThemeChanger.Event.BootstrapThemeChanged event."""
+        self.refresh_icons()
 
 
 class ThemeChanger:

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -3,17 +3,30 @@
 import asyncio
 import enum
 import functools
+import json
 import logging
 import tkinter as tk
+import webbrowser
 from collections.abc import Callable
+from tkinter import font
 
 import ttkbootstrap as ttk
 import ttkbootstrap.icons as ttk_icons
 import ttkbootstrap.style as ttk_style
 import ttkbootstrap.themes.standard as ttk_themes
+from tkfontawesome import icon_to_image
 from ttkbootstrap import constants as bootstyle
 
+from qtpy_datalogger import datatypes
+
 logger = logging.getLogger(__name__)
+
+
+class StyleKey(enum.StrEnum):
+    """A class that extends the palette names of ttkbootstrap styles."""
+
+    Fg = "fg"
+    SelectFg = "selectfg"
 
 
 class AsyncApp:
@@ -221,6 +234,148 @@ class AsyncWindow:
     def exit(self) -> None:
         """Close the window and exit."""
         self.should_run_loop = False
+
+
+class AboutDialog(AsyncDialog):
+    """A class that presents information about the app."""
+
+    def __init__(  # noqa PLR0913 -- allow many parameters for a framework class
+        self,
+        parent: ttk.Toplevel | ttk.Window,
+        app_name: str = "",
+        app_icon: str = "",
+        all_icons: list[str] | None = None,
+        help_url: str = "",
+        source_url: str = "",
+    ) -> None:
+        """Initialize a new AboutDialog instance."""
+        self.app_name = app_name
+        if not app_icon:
+            app_icon = "chart-line"
+        if not all_icons:
+            all_icons = ["microchip", "worm", app_icon]
+        self.app_icons = all_icons[:3]
+        self.app_icon_images = []
+        self.help_url = help_url or datatypes.Links.Homepage
+        self.source_url = source_url or datatypes.Links.Source
+        self.copy_version_text = "Copy version"
+        super().__init__(parent, f"About {app_name}".strip())
+
+    def create_user_interface(self) -> None:  # noqa: PLR0915 -- allow long function to create the UI
+        """Create the UI for the AboutDialog."""
+        self.root_window.columnconfigure(0, weight=1)
+        self.root_window.rowconfigure(0, weight=1)
+        self.root_window.resizable(width=False, height=False)
+        main_frame = ttk.Frame(self.root_window, padding=16)
+        main_frame.grid(column=0, row=0, sticky=tk.NSEW)
+        main_frame.columnconfigure(0, weight=1)
+        main_frame.rowconfigure(0, weight=1)
+        main_frame.rowconfigure(1, weight=1)
+
+        message_frame = ttk.Frame(main_frame)
+        message_frame.grid(column=0, row=0, sticky=tk.NSEW)
+        message_frame.columnconfigure(0, weight=0, minsize=40)  # Filler
+        message_frame.columnconfigure(1, weight=0)  # Icon1
+        message_frame.columnconfigure(2, weight=0)  # Icon2
+        message_frame.columnconfigure(3, weight=0)  # Icon3
+        message_frame.columnconfigure(4, weight=0, minsize=20)  # Filler
+        message_frame.columnconfigure(5, weight=0)  # Text
+        message_frame.columnconfigure(6, weight=0, minsize=40)  # Filler
+        message_frame.rowconfigure(0, weight=0, minsize=20)  # Filler
+        message_frame.rowconfigure(1, weight=0)  # Icons and Name
+        message_frame.rowconfigure(2, weight=0)  # Icons and Version
+        message_frame.rowconfigure(3, weight=0)  # Separator
+        message_frame.rowconfigure(4, weight=0)  # Help
+        message_frame.rowconfigure(5, weight=0)  # Source
+        message_frame.rowconfigure(6, weight=0)  # Source2
+        message_frame.rowconfigure(7, weight=0, minsize=50)  # Filler
+
+        icon_height = 48
+        icon_color = hex_string_for_style(StyleKey.Fg)
+        icon_column = 3
+        for icon_name in reversed(self.app_icons):
+            icon_image = icon_to_image(icon_name, fill=icon_color, scale_to_height=icon_height)
+            self.app_icon_images.append(icon_image)
+            chart_label = ttk.Label(message_frame, image=icon_image, padding=4)
+            chart_label.grid(column=icon_column, row=1, rowspan=2)
+            icon_column = icon_column - 1
+
+        name_label = ttk.Label(message_frame, font=font.Font(weight="bold", size=28), text=self.app_name)
+        name_label.grid(column=5, row=1, sticky=tk.W)
+        self.notice_information = datatypes.SnsrNotice.get_package_notice_info(allow_dev_version=True)
+        bullet = ttk_icons.Emoji.get("black medium small square")
+        version_label = ttk.Label(
+            message_frame,
+            text=f"{self.notice_information.version} {bullet} {self.notice_information.timestamp:%Y-%m-%d} {bullet} {self.notice_information.commit}",
+        )
+        version_label.grid(column=5, row=2, sticky=tk.W, padx=(2, 0))
+        separator = ttk.Separator(message_frame)
+        separator.grid(column=1, row=3, columnspan=5, sticky=tk.EW, pady=4)
+        button_text_color = hex_string_for_style(StyleKey.SelectFg)
+        spacer = "   "
+        self.help_icon = icon_to_image("parachute-box", fill=button_text_color, scale_to_width=16)
+        help_button = ttk.Button(
+            message_frame,
+            compound=tk.LEFT,
+            image=self.help_icon,
+            text=f"{spacer}Online help ",  # The trailing space helps with internal margins
+            style=bootstyle.INFO,
+            width=18,
+            command=functools.partial(webbrowser.open_new_tab, self.help_url),
+        )
+        help_button.grid(column=5, row=4, sticky=tk.W, pady=(18, 0))
+        self.source_icon = icon_to_image("github-alt", fill=button_text_color, scale_to_width=16)
+        source_button = ttk.Button(
+            message_frame,
+            compound=tk.LEFT,
+            image=self.source_icon,
+            text=f"{spacer}Source code",
+            style=bootstyle.INFO,
+            width=18,
+            command=functools.partial(webbrowser.open_new_tab, self.source_url),
+        )
+        source_button.grid(column=5, row=5, sticky=tk.W, pady=(22, 0))
+
+        button_frame = ttk.Frame(main_frame)
+        button_frame.grid(column=0, row=1, sticky=tk.NSEW, padx=(0, 16), pady=(8, 0))
+        button_frame.columnconfigure(0, weight=1)
+        button_frame.columnconfigure(1, weight=0)
+        button_frame.rowconfigure(0, weight=0)
+        self.copy_version_button = ttk.Button(
+            button_frame,
+            text=self.copy_version_text,
+            style=bootstyle.OUTLINE,
+            command=self.copy_version,
+            width=12,
+        )
+        self.copy_version_button.grid(column=0, row=0, sticky=tk.E, padx=(0, 16))
+        ok_button = ttk.Button(button_frame, text="OK", command=self.exit)
+        ok_button.grid(column=1, row=0, sticky=tk.E)
+        self.initial_focus = ok_button
+
+    def copy_version(self) -> None:
+        """Copy the version information to the clipboard."""
+        formatted_version = {
+            "version": self.notice_information.version,
+            "timestamp": str(self.notice_information.timestamp),
+            "commit": self.notice_information.commit,
+        }
+        self.parent.clipboard_clear()
+        self.parent.clipboard_append(json.dumps(formatted_version))
+        status_emoji = ttk_icons.Emoji.get("white heavy check mark")
+        self.copy_version_button.configure(text=f"{status_emoji}   Copied!", bootstyle=bootstyle.SUCCESS)
+        self.copy_version_button.after(
+            850,
+            functools.partial(
+                self.copy_version_button.configure,
+                text=self.copy_version_text,
+                bootstyle=(bootstyle.DEFAULT, bootstyle.OUTLINE),  # pyright: ignore callIssue -- the type hints do not understand tuples
+            ),
+        )
+
+    async def on_loop(self) -> None:
+        """Update UI elements."""
+        await asyncio.sleep(20e-3)
 
 
 class ThemeChanger:


### PR DESCRIPTION
## Summary

This PR adds an `AboutDialog` class to `guikit` for apps to reuse.

## Design

- Move the `AboutDialog` from the Data Viewer app
  - Convert it to an `AsyncDialog`
- Add class method `show_no_wait()` to `AsyncDialog` to make presenting fire-and-forget dialogs safe
- Use `StyleKey` to lookup ttkbootstrap colors for styling button text and icons

## Screenshots or logs

<img width="1173" height="802" alt="about-dialog-demo gif" src="https://github.com/user-attachments/assets/aa59119b-c94f-4901-bc4d-c2458ee21847" />

## Testing

See screen capture above.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
