### PR TITLE
Host API: Add helper method for creating select-only comboboxes

### DIFF
--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -9,7 +9,7 @@ import tkinter as tk
 import webbrowser
 from collections.abc import Callable
 from tkinter import font
-from typing import ClassVar, NamedTuple
+from typing import ClassVar, Literal, NamedTuple
 
 import click
 import ttkbootstrap as ttk
@@ -796,6 +796,30 @@ def show_button_feedback(
             bootstyle=normal_style,
         ),
     )
+
+
+def create_dropdown_combobox(
+    parent: tk.Misc,
+    values: list[str],
+    width: int,
+    justify: Literal["left", "center", "right"],
+    completion: Callable[[str], None],
+) -> ttk.Combobox:
+    """Create a ttk.Combobox that only allows selection of entries."""
+
+    def handle_selection(event_args: tk.Event) -> None:
+        """Handle the selection event for the combobox."""
+        sender = event_args.widget
+        if not isinstance(sender, ttk.Combobox):
+            raise TypeError()
+        sender.selection_clear()
+        selected_value = sender.get()
+        completion(selected_value)
+
+    combobox = ttk.Combobox(parent, justify=justify, state=bootstyle.READONLY, values=values, width=width)
+    combobox.bind("<<ComboboxSelected>>", handle_selection)
+    combobox.selection_clear()
+    return combobox
 
 
 def hex_string_for_style(style_name: str, theme_name: str = "") -> str:


### PR DESCRIPTION
## Summary

This PR adds a helper method named `create_dropdown_combobox()` that allows apps to create a dropdown combobox with a collection of possible values.

## Design

- Use `bootstyle.READONLY` and `selection_clear()` to make the combobox behave as though it is read-only

## Screenshots or logs

_None_

## Testing

_None_

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
