### PR TITLE
Host API: Add open_folder() to guikit

### DIFF
--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -5,6 +5,8 @@ import enum
 import functools
 import json
 import logging
+import pathlib
+import subprocess
 import tkinter as tk
 import webbrowser
 from collections.abc import Callable
@@ -831,6 +833,12 @@ def hex_string_for_style(style_name: str, theme_name: str = "") -> str:
         theme_name = style.theme.name
     palette = ttk_themes.STANDARD_THEMES[theme_name]["colors"]
     return palette[style_name]
+
+
+def open_folder(path: pathlib.Path) -> None:
+    """Open Windows Explorer to the specified folder."""
+    target = path if path.is_dir() else path.parent
+    subprocess.run(["powershell", "-Command", f"Invoke-Item '{target!s}'"], check=True)  # noqa: S603 S607 -- user input not accepted for this call
 
 
 def toggle_visual_debug(frame: tk.Widget) -> None:


### PR DESCRIPTION
## Summary

This PR adds a helper function named `open_folder()` that opens Windows Explorer to the specified folder.

## Design

Use `powershell -Invoke-Item {folder}`

### Details

_Note:_ `click` has a similar built-in mechanism with `click.launch(some_path, locate=True)` but it fails when the path has space characters (https://github.com/pallets/click/issues/2994).

In addition, its implementation uses `explorer /select,{some_path}` which has an important behavior difference. When the target is a _folder_, `explorer /select` opens the _parent_ folder and _focuses_ the target folder, which is expected behavior for `/select`.

## Screenshots or logs

None

## Testing

None

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
