### PR TITLE
Node API: Add settings singleton

### DIFF
--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -1,34 +1,33 @@
 """code.py file is the main loop from qtpy_datalogger.sensor_node."""  # noqa: INP001 -- this is the entry point for CircuitPython devices
 
-import os
 from time import monotonic, sleep
 
 from microcontroller import cpu
 from snsr.core import get_memory_info, paint_uart_line, read_one_uart_line
 from snsr.rxtx import connect_and_subscribe, connect_to_wifi, create_mqtt_client, unsubscribe_and_disconnect
+from snsr.settings import settings
 from supervisor import runtime
 
-boot_time = monotonic()
-print(f"Booted at {boot_time:.3f}")  # noqa: T201 -- use direct IO for user REPL
-radio = connect_to_wifi()
+settings.boot_time = monotonic()
+print(f"Booted at {settings.boot_time:.3f}")  # noqa: T201 -- use direct IO for user REPL
 
-node_group = os.getenv("QTPY_NODE_GROUP", "zone1")
 node_identifier = f"node-{cpu.uid.hex().lower()}-0"  # Matches boot_out.txt
 mqtt_topics = [
-    f"qtpy/v1/{node_group}/broadcast",
-    f"qtpy/v1/{node_group}/{node_identifier}/command",
+    f"qtpy/v1/{settings.node_group}/broadcast",
+    f"qtpy/v1/{settings.node_group}/{node_identifier}/command",
 ]
 
-mqtt_client = create_mqtt_client(radio, node_group, node_identifier)
+radio = connect_to_wifi()
+mqtt_client = create_mqtt_client(radio, settings.node_group, node_identifier)
 connect_and_subscribe(mqtt_client, mqtt_topics)
 
 response = ""
 while response.lower() not in ["exit", "quit"]:
-    uptime = monotonic() - boot_time
+    uptime = monotonic() - settings.boot_time
     paint_uart_line(f"  {uptime:>12.3f}    Poll UART     [ Poll MQTT ]     ")
     mqtt_client.loop()
 
-    uptime = monotonic() - boot_time
+    uptime = monotonic() - settings.boot_time
     paint_uart_line(f"  {uptime:>12.3f}  [ Poll UART ]     Poll MQTT       ")
     sleep(0.2)
     if runtime.usb_connected and runtime.serial_connected and runtime.serial_bytes_available > 0:

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -1,7 +1,5 @@
 """Classes and functions for control and communication over MQTT."""
 
-import os
-
 import adafruit_connection_manager
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
@@ -9,12 +7,13 @@ import wifi
 from snsr.core import get_new_descriptor, get_notice_info
 from snsr.node.classes import DescriptorInformation, NoticeInformation, SenderInformation
 from snsr.node.mqtt import get_descriptor_topic, get_result_topic
+from snsr.settings import settings
 
 
 def connect_to_wifi() -> wifi.Radio:
     """Connect to the SSID from settings.toml and return the radio instance."""
     wifi.radio.enabled = True
-    wifi.radio.connect(os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD"))
+    wifi.radio.connect(settings.wifi_ssid, settings.wifi_password)
     return wifi.radio
 
 
@@ -107,7 +106,7 @@ def create_mqtt_client(radio: wifi.Radio, node_group: str, node_identifier: str)
     # Set up a MiniMQTT Client
     pool = adafruit_connection_manager.get_radio_socketpool(radio)
     mqtt_client = minimqtt.MQTT(
-        broker=os.getenv("QTPY_BROKER_IP_ADDRESS", ""),
+        broker=settings.mqtt_broker,
         socket_pool=pool,
         user_data={
             "node_group": node_group,
@@ -157,11 +156,9 @@ def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> st
     from snsr.node.mqtt import format_mqtt_client_id, get_descriptor_topic
 
     pid = 0
-    group_id = os.getenv("QTPY_NODE_GROUP", "zone1")
-
     descriptor = build_descriptor_information(role, serial_number, ip_address)
     client_id = format_mqtt_client_id(role, serial_number, pid)
-    descriptor_topic = get_descriptor_topic(group_id, client_id)
+    descriptor_topic = get_descriptor_topic(settings.node_group, client_id)
     sender = build_sender_information(descriptor_topic)
     response = DescriptorPayload(descriptor=descriptor, sender=sender)
     return json.dumps(response.as_dict())

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -1,0 +1,87 @@
+"""Global settings used by the sensor_node runtime."""
+
+import board
+import digitalio
+
+
+class Settings:
+    """A singleton that holds the global settings used by the sensor_node runtime."""
+
+    _instance: "Settings"
+
+    def __new__(cls) -> "Settings":
+        """Return the singleton instance, creating it beforehand if necessary."""
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self) -> None:
+        """Initialize the instance."""
+        self._initialize_from_env()
+        self._initialize_dynamic_settings()
+        self._dio_pins = {}
+
+    def _initialize_from_env(self) -> None:
+        """Initialize the readonly settings from the environment variables."""
+        from os import getenv
+
+        self._wifi_ssid = getenv("CIRCUITPY_WIFI_SSID", "")
+        self._wifi_password = getenv("CIRCUITPY_WIFI_PASSWORD", "")
+        self._mqtt_broker = getenv("QTPY_BROKER_IP_ADDRESS", "")
+        self._node_group = getenv("QTPY_NODE_GROUP", "zone1")
+        self._node_name = getenv("QTPY_NODE_NAME", "node1")
+
+    def _initialize_dynamic_settings(self) -> None:
+        """Initialize the read-write settings."""
+        self._boot_time = -1.0
+
+    @property
+    def wifi_ssid(self) -> str:
+        """Return the WiFi SSID from the settings.toml file."""
+        return self._wifi_ssid
+
+    @property
+    def wifi_password(self) -> str:
+        """Return the WiFi password from the settings.toml file."""
+        return self._wifi_password
+
+    @property
+    def mqtt_broker(self) -> str:
+        """Return the MQTT broker IP address from the settings.toml file."""
+        return self._mqtt_broker
+
+    @property
+    def node_group(self) -> str:
+        """Return the name of the group for the sensor_node."""
+        return self._node_group
+
+    @property
+    def node_name(self) -> str:
+        """Return the name of the sensor_node."""
+        return self._node_name
+
+    @property
+    def boot_time(self) -> float:
+        """Return the node's time since boot in milliseconds."""
+        return self._boot_time
+
+    @boot_time.setter
+    def boot_time(self, new_boot_time: float) -> None:
+        """Set a new value for the node's boot time."""
+        self._boot_time = new_boot_time
+
+    def get_dio_pin(self, pin_name: str) -> digitalio.DigitalInOut:
+        """Initialize the pin instance that matches the board's pin_name."""
+        if pin_name not in self._dio_pins:
+            self._dio_pins[pin_name] = digitalio.DigitalInOut(getattr(board, pin_name))
+        return self._dio_pins[pin_name]
+
+    def release_dio_pin(self, pin_name: str) -> None:
+        """De-initialize the pin instance that matches the board's pin_name."""
+        if pin_name not in self._dio_pins:
+            return
+        self._dio_pins[pin_name].deinit()
+        del self._dio_pins[pin_name]
+
+
+settings = Settings()

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -13,13 +13,17 @@ class Settings:
         """Return the singleton instance, creating it beforehand if necessary."""
         if not hasattr(cls, "_instance"):
             cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
         return cls._instance
 
     def __init__(self) -> None:
         """Initialize the instance."""
+        if self._initialized:
+            return
         self._initialize_from_env()
         self._initialize_dynamic_settings()
         self._dio_pins = {}
+        self._initialized = True
 
     def _initialize_from_env(self) -> None:
         """Initialize the readonly settings from the environment variables."""


### PR DESCRIPTION
## Summary

This PR adds a `Settings` singleton class for the node's settings like WiFi credentials, MQTT identifiers, and QT Py resources.

## Design

- Implement a singleton using `__new__()` to force a single instance

## Screenshots or logs

<img width="640" height="852" alt="image" src="https://github.com/user-attachments/assets/070b2959-059d-4202-a575-ff38bac565ac" />

## Testing

- The node still connects to the network and MQTT broker
- The scanner app can detect and communicate with a node

## Checklist

- [x] Issues linked / labels applied
- [x] Documentation updated
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
