### PR TITLE
Node API: Add handlers submodule

### DIFF
--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -1,0 +1,72 @@
+"""Functions that handle API commands."""
+
+from snsr.core import get_new_descriptor, get_notice_info
+from snsr.node.classes import (
+    DescriptorInformation,
+    NoticeInformation,
+    SenderInformation,
+)
+from snsr.settings import settings
+
+
+def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:
+    """Return a serialized string representation of the DescriptorPayload."""
+    from json import dumps
+
+    from snsr.node.classes import DescriptorPayload
+    from snsr.node.mqtt import format_mqtt_client_id, get_descriptor_topic
+
+    pid = 0
+    descriptor = build_descriptor_information(role, serial_number, ip_address)
+    client_id = format_mqtt_client_id(role, serial_number, pid)
+    descriptor_topic = get_descriptor_topic(settings.node_group, client_id)
+    sender = build_sender_information(descriptor_topic)
+    response = DescriptorPayload(descriptor=descriptor, sender=sender)
+    return dumps(response.as_dict())
+
+
+def build_descriptor_information(role: str, serial_number: str, ip_address: str) -> DescriptorInformation:
+    """Return a DescriptorInformation instance describing and identifying the client."""
+    from os import uname
+    from sys import implementation, version_info
+
+    from board import board_id
+
+    pid = 0
+    system_info = uname()
+    micropython_base = ".".join([f"{version_number}" for version_number in version_info])
+    python_implementation = f"{implementation.name}-{system_info.release}"
+    notice_info = get_notice_info()
+    notice = NoticeInformation(**notice_info)
+
+    descriptor = get_new_descriptor(
+        role=role,
+        serial_number=serial_number,
+        pid=pid,
+        hardware_name=board_id,
+        micropython_base=micropython_base,
+        python_implementation=python_implementation,
+        ip_address=ip_address,
+        notice=notice,
+    )
+    return descriptor
+
+
+def build_sender_information(descriptor_topic: str) -> SenderInformation:
+    """Return a SenderInformation instance describing the client's current state."""
+    from gc import mem_alloc, mem_free
+    from time import monotonic
+
+    from microcontroller import cpu
+
+    from snsr.node.classes import SenderInformation, StatusInformation
+
+    used_bytes = mem_alloc()
+    free_bytes = mem_free()
+    cpu_celsius = cpu.temperature
+    monotonic_time = monotonic()
+    status = StatusInformation(
+        used_memory=str(used_bytes), free_memory=str(free_bytes), cpu_temperature=str(cpu_celsius)
+    )
+    sender = SenderInformation(descriptor_topic=descriptor_topic, sent_at=str(monotonic_time), status=status)
+    return sender

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -1,12 +1,25 @@
 """Functions that handle API commands."""
 
-from snsr.core import get_new_descriptor, get_notice_info
+import adafruit_minimqtt.adafruit_minimqtt as minimqtt
+
 from snsr.node.classes import (
     DescriptorInformation,
-    NoticeInformation,
     SenderInformation,
 )
 from snsr.settings import settings
+
+
+def handle_identify(client: minimqtt.MQTT) -> None:
+    """Respond to the the identify command."""
+    from microcontroller import cpu
+    from wifi import radio
+
+    from snsr.node.mqtt import get_descriptor_topic
+
+    context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
+    descriptor_topic = get_descriptor_topic(context["node_group"], context["node_identifier"])
+    descriptor_message = get_descriptor_payload("node", cpu.uid.hex().lower(), str(radio.ipv4_address))
+    client.publish(descriptor_topic, descriptor_message)
 
 
 def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:
@@ -31,6 +44,9 @@ def build_descriptor_information(role: str, serial_number: str, ip_address: str)
     from sys import implementation, version_info
 
     from board import board_id
+
+    from snsr.core import get_new_descriptor, get_notice_info
+    from snsr.node.classes import NoticeInformation
 
     pid = 0
     system_info = uname()

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -1,11 +1,14 @@
 """Functions that handle API commands."""
 
+from json import dumps
+
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 
 from snsr.node.classes import (
     DescriptorInformation,
     SenderInformation,
 )
+from snsr.node.mqtt import get_descriptor_topic
 from snsr.settings import settings
 
 
@@ -14,20 +17,51 @@ def handle_identify(client: minimqtt.MQTT) -> None:
     from microcontroller import cpu
     from wifi import radio
 
-    from snsr.node.mqtt import get_descriptor_topic
-
     context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
     descriptor_topic = get_descriptor_topic(context["node_group"], context["node_identifier"])
     descriptor_message = get_descriptor_payload("node", cpu.uid.hex().lower(), str(radio.ipv4_address))
     client.publish(descriptor_topic, descriptor_message)
 
 
+def handle_command_message(client: minimqtt.MQTT, message: str) -> None:
+    """Respond to a message sent to the command topic for the node."""
+    from json import loads
+    from time import sleep
+
+    from .node.classes import ActionInformation, ActionPayload
+    from .node.mqtt import get_result_topic
+
+    if not message:
+        return
+    try:
+        action_payload_information = loads(message)
+    except ValueError:
+        return
+    node_context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
+    action_payload = ActionPayload.from_dict(action_payload_information)
+    action_information = action_payload.action
+    descriptor_topic = get_descriptor_topic(node_context["node_group"], node_context["node_identifier"])
+    sender = build_sender_information(descriptor_topic)
+    result_payload = ActionPayload(
+        action=ActionInformation(
+            command=action_information.command,
+            parameters={
+                "output": f"received: {action_information.parameters['input']}",
+                "complete": True,
+            },
+            message_id=action_information.message_id,
+        ),
+        sender=sender,
+    )
+    result_topic = get_result_topic(node_context["node_group"], node_context["node_identifier"])
+    client.publish(result_topic, dumps(result_payload.as_dict()))
+    sleep(0.2)  # Allow the backend to send the message
+
+
 def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:
     """Return a serialized string representation of the DescriptorPayload."""
-    from json import dumps
-
     from snsr.node.classes import DescriptorPayload
-    from snsr.node.mqtt import format_mqtt_client_id, get_descriptor_topic
+    from snsr.node.mqtt import format_mqtt_client_id
 
     pid = 0
     descriptor = build_descriptor_information(role, serial_number, ip_address)

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -4,7 +4,7 @@ import adafruit_connection_manager
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
 
-from snsr.handlers import build_sender_information, get_descriptor_payload
+from snsr.handlers import build_sender_information, handle_identify
 from snsr.node.mqtt import get_descriptor_topic, get_result_topic
 from snsr.settings import settings
 
@@ -67,13 +67,7 @@ def on_message(client: minimqtt.MQTT, topic: str, message: str) -> None:
     topic_parts = topic.split("/")
     last_part = topic_parts[-1]
     if last_part == "broadcast":
-        from microcontroller import cpu
-        from wifi import radio
-
-        context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
-        descriptor_topic = get_descriptor_topic(context["node_group"], context["node_identifier"])
-        descriptor_message = get_descriptor_payload("node", cpu.uid.hex().lower(), str(radio.ipv4_address))
-        client.publish(descriptor_topic, descriptor_message)
+        handle_identify(client)
     elif last_part == "command":
         from json import dumps, loads
 

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -4,8 +4,7 @@ import adafruit_connection_manager
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
 
-from snsr.handlers import build_sender_information, handle_identify
-from snsr.node.mqtt import get_descriptor_topic, get_result_topic
+from snsr.handlers import handle_command_message, handle_identify
 from snsr.settings import settings
 
 
@@ -69,29 +68,7 @@ def on_message(client: minimqtt.MQTT, topic: str, message: str) -> None:
     if last_part == "broadcast":
         handle_identify(client)
     elif last_part == "command":
-        from json import dumps, loads
-
-        from .node.classes import ActionInformation, ActionPayload
-
-        context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
-        action_payload_information = loads(message)
-        action_payload = ActionPayload.from_dict(action_payload_information)
-        action = action_payload.action
-        descriptor_topic = get_descriptor_topic(context["node_group"], context["node_identifier"])
-        sender = build_sender_information(descriptor_topic)
-        result_payload = ActionPayload(
-            action=ActionInformation(
-                command=action.command,
-                parameters={
-                    "output": f"received: {action.parameters['input']}",
-                    "complete": True,
-                },
-                message_id=action.message_id,
-            ),
-            sender=sender,
-        )
-        result_topic = get_result_topic(context["node_group"], context["node_identifier"])
-        client.publish(result_topic, dumps(result_payload.as_dict()))
+        handle_command_message(client, message)
 
 
 def create_mqtt_client(radio: wifi.Radio, node_group: str, node_identifier: str) -> minimqtt.MQTT:

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -1,6 +1,5 @@
 """Classes and functions for control and communication over MQTT."""
 
-import adafruit_connection_manager
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
 
@@ -73,8 +72,10 @@ def on_message(client: minimqtt.MQTT, topic: str, message: str) -> None:
 
 def create_mqtt_client(radio: wifi.Radio, node_group: str, node_identifier: str) -> minimqtt.MQTT:
     """Create an MQTT client and set its callback functions."""
+    from adafruit_connection_manager import get_radio_socketpool
+
     # Set up a MiniMQTT Client
-    pool = adafruit_connection_manager.get_radio_socketpool(radio)
+    pool = get_radio_socketpool(radio)
     mqtt_client = minimqtt.MQTT(
         broker=settings.mqtt_broker,
         socket_pool=pool,

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -4,8 +4,7 @@ import adafruit_connection_manager
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
 
-from snsr.core import get_new_descriptor, get_notice_info
-from snsr.node.classes import DescriptorInformation, NoticeInformation, SenderInformation
+from snsr.handlers import build_sender_information, get_descriptor_payload
 from snsr.node.mqtt import get_descriptor_topic, get_result_topic
 from snsr.settings import settings
 
@@ -146,66 +145,3 @@ def do_full_client_publish(mqtt_client: minimqtt.MQTT, message: str) -> None:
     mqtt_client.publish(mqtt_topic, message)
     mqtt_client.unsubscribe(mqtt_topic)
     mqtt_client.disconnect()
-
-
-def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:
-    """Return a serialized string representation of the DescriptorPayload."""
-    import json
-
-    from snsr.node.classes import DescriptorPayload
-    from snsr.node.mqtt import format_mqtt_client_id, get_descriptor_topic
-
-    pid = 0
-    descriptor = build_descriptor_information(role, serial_number, ip_address)
-    client_id = format_mqtt_client_id(role, serial_number, pid)
-    descriptor_topic = get_descriptor_topic(settings.node_group, client_id)
-    sender = build_sender_information(descriptor_topic)
-    response = DescriptorPayload(descriptor=descriptor, sender=sender)
-    return json.dumps(response.as_dict())
-
-
-def build_descriptor_information(role: str, serial_number: str, ip_address: str) -> DescriptorInformation:
-    """Return a DescriptorInformation instance describing and identifying the client."""
-    from os import uname
-    from sys import implementation, version_info
-
-    from board import board_id
-
-    pid = 0
-    system_info = uname()
-    micropython_base = ".".join([f"{version_number}" for version_number in version_info])
-    python_implementation = f"{implementation.name}-{system_info.release}"
-    notice_info = get_notice_info()
-    notice = NoticeInformation(**notice_info)
-
-    descriptor = get_new_descriptor(
-        role=role,
-        serial_number=serial_number,
-        pid=pid,
-        hardware_name=board_id,
-        micropython_base=micropython_base,
-        python_implementation=python_implementation,
-        ip_address=ip_address,
-        notice=notice,
-    )
-    return descriptor
-
-
-def build_sender_information(descriptor_topic: str) -> SenderInformation:
-    """Return a SenderInformation instance describing the client's current state."""
-    import gc
-    from time import monotonic
-
-    from microcontroller import cpu
-
-    from snsr.node.classes import SenderInformation, StatusInformation
-
-    used_bytes = gc.mem_alloc()
-    free_bytes = gc.mem_free()
-    cpu_celsius = cpu.temperature
-    monotonic_time = monotonic()
-    status = StatusInformation(
-        used_memory=str(used_bytes), free_memory=str(free_bytes), cpu_temperature=str(cpu_celsius)
-    )
-    sender = SenderInformation(descriptor_topic=descriptor_topic, sent_at=str(monotonic_time), status=status)
-    return sender


### PR DESCRIPTION
## Summary

This PR adds a new `snsr` submodule named `handlers` to handle messages and build payloads.

The `rxtx` submodule's purpose is to support MQTT communication, and the `handlers` submodule's purpose is to support application-specific operations on the received messages.

## Design

Move functions from `rxtx` to the new submodule.

## Screenshots or logs

<img width="641" height="852" alt="image" src="https://github.com/user-attachments/assets/90f91799-f4a3-4440-972d-a5a784e0e1f1" />

## Testing

- The node connects to the MQTT broker
- The node responds to messages

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
