### PR TITLE
Node API: Add a broadcast message handler

### DIFF
--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -1,6 +1,6 @@
 """Functions that handle API commands."""
 
-from json import dumps
+from json import dumps, loads
 
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 
@@ -15,8 +15,6 @@ from snsr.settings import settings
 
 def handle_broadcast_message(client: minimqtt.MQTT, message: str) -> None:
     """Respond to a message sent to the broadcast topic for the node's group."""
-    from json import loads
-
     if not message:
         return
     try:
@@ -46,7 +44,6 @@ def handle_identify(client: minimqtt.MQTT) -> None:
 
 def handle_command_message(client: minimqtt.MQTT, message: str) -> None:
     """Respond to a message sent to the command topic for the node."""
-    from json import loads
     from time import sleep
 
     from .node.classes import ActionInformation

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -5,11 +5,32 @@ from json import dumps
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 
 from snsr.node.classes import (
+    ActionPayload,
     DescriptorInformation,
     SenderInformation,
 )
 from snsr.node.mqtt import get_descriptor_topic
 from snsr.settings import settings
+
+
+def handle_broadcast_message(client: minimqtt.MQTT, message: str) -> None:
+    """Respond to a message sent to the broadcast topic for the node's group."""
+    from json import loads
+
+    if not message:
+        return
+    try:
+        action_payload_information = loads(message)
+    except ValueError:
+        return
+    action_payload = ActionPayload.from_dict(action_payload_information)
+    action = action_payload.action
+    if action.command == "identify":
+        handle_identify(client)
+        return
+
+    # Fallback: forward to node as a command
+    handle_command_message(client, message)
 
 
 def handle_identify(client: minimqtt.MQTT) -> None:
@@ -28,7 +49,7 @@ def handle_command_message(client: minimqtt.MQTT, message: str) -> None:
     from json import loads
     from time import sleep
 
-    from .node.classes import ActionInformation, ActionPayload
+    from .node.classes import ActionInformation
     from .node.mqtt import get_result_topic
 
     if not message:

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -13,22 +13,27 @@ from snsr.node.mqtt import get_descriptor_topic
 from snsr.settings import settings
 
 
-def handle_broadcast_message(client: minimqtt.MQTT, message: str) -> None:
-    """Respond to a message sent to the broadcast topic for the node's group."""
+def can_handle_message(message: str) -> None | ActionPayload:
+    """Return an ActionPayload if the node can respond to the message."""
     if not message:
-        return
+        return None
     try:
         action_payload_information = loads(message)
     except ValueError:
-        return
+        return None
     action_payload = ActionPayload.from_dict(action_payload_information)
+    return action_payload
+
+
+def handle_broadcast_message(client: minimqtt.MQTT, action_payload: ActionPayload) -> None:
+    """Respond to a message sent to the broadcast topic for the node's group."""
     action = action_payload.action
     if action.command == "identify":
         handle_identify(client)
         return
 
     # Fallback: forward to node as a command
-    handle_command_message(client, message)
+    handle_command_message(client, action_payload)
 
 
 def handle_identify(client: minimqtt.MQTT) -> None:
@@ -42,21 +47,14 @@ def handle_identify(client: minimqtt.MQTT) -> None:
     client.publish(descriptor_topic, descriptor_message)
 
 
-def handle_command_message(client: minimqtt.MQTT, message: str) -> None:
+def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload) -> None:
     """Respond to a message sent to the command topic for the node."""
     from time import sleep
 
     from .node.classes import ActionInformation
     from .node.mqtt import get_result_topic
 
-    if not message:
-        return
-    try:
-        action_payload_information = loads(message)
-    except ValueError:
-        return
     node_context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
-    action_payload = ActionPayload.from_dict(action_payload_information)
     action_information = action_payload.action
     descriptor_topic = get_descriptor_topic(node_context["node_group"], node_context["node_identifier"])
     sender = build_sender_information(descriptor_topic)

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -3,7 +3,11 @@
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
 
-from snsr.handlers import handle_broadcast_message, handle_command_message
+from snsr.handlers import (
+    can_handle_message,
+    handle_broadcast_message,
+    handle_command_message,
+)
 from snsr.settings import settings
 
 
@@ -64,10 +68,13 @@ def on_message(client: minimqtt.MQTT, topic: str, message: str) -> None:
     # > print(f"New message on topic {topic}: {message}")
     topic_parts = topic.split("/")
     last_part = topic_parts[-1]
+    action_payload = can_handle_message(message)
+    if not action_payload:
+        return
     if last_part == "broadcast":
-        handle_broadcast_message(client, message)
+        handle_broadcast_message(client, action_payload)
     elif last_part == "command":
-        handle_command_message(client, message)
+        handle_command_message(client, action_payload)
 
 
 def create_mqtt_client(radio: wifi.Radio, node_group: str, node_identifier: str) -> minimqtt.MQTT:

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -3,7 +3,7 @@
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 import wifi
 
-from snsr.handlers import handle_command_message, handle_identify
+from snsr.handlers import handle_broadcast_message, handle_command_message
 from snsr.settings import settings
 
 
@@ -65,7 +65,7 @@ def on_message(client: minimqtt.MQTT, topic: str, message: str) -> None:
     topic_parts = topic.split("/")
     last_part = topic_parts[-1]
     if last_part == "broadcast":
-        handle_identify(client)
+        handle_broadcast_message(client, message)
     elif last_part == "command":
         handle_command_message(client, message)
 


### PR DESCRIPTION
## Summary

This PR adds a broadcast message handler to the sensor node. This allows the code to add handlers for more broadcast messages in addition to `identify`.

It also handles empty, malformed, and unrelated messages by returning early.

## Design

- Add a new function named `can_handle_message()`
  - Return early if the message is empty or malformed
- Add a new function named `handle_broadcast_message()`
  - Dispatch to a command-specific handler

## Screenshots or logs

<img width="643" height="854" alt="image" src="https://github.com/user-attachments/assets/06a1b839-b927-4759-8b91-e44609b0e7c9" />

## Testing

- The node connects to the MQTT broker
- The node responds to commands

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
