### PR TITLE
Node API: Add apps API

### DIFF
--- a/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
@@ -1,0 +1,31 @@
+"""Matching sensor_node apps for their host-side qtpy_datalogger.apps."""
+
+try:  # noqa: SIM105 -- contextlib is not available for CircuitPython
+    from collections.abc import Callable
+except ImportError:
+    pass
+
+from snsr.node.classes import ActionInformation
+
+
+def get_catalog() -> list[str]:
+    """Return a list of the selectable apps."""
+    from os import listdir
+
+    files = listdir(str(__path__))  # noqa: PTH208 -- pathlib not available on CircuitPython
+    apps = [file.split(".")[0] for file in files if not file.startswith("__init__")]
+    return apps
+
+
+def get_handler(snsr_app_name: str) -> Callable[[ActionInformation], ActionInformation]:
+    """Return the handler that matches snsr_app_name."""
+    from snsr.apps import echo
+
+    return echo.handle_message
+
+
+def get_handler_completion(snsr_app_name: str) -> Callable[[ActionInformation], None]:
+    """Return the completion that matches snsr_app_name."""
+    from snsr.apps import echo
+
+    return echo.did_handle_message

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
@@ -1,0 +1,20 @@
+"""Simple 'echo' app that repeats every message received."""
+
+from snsr.node.classes import ActionInformation
+
+
+def handle_message(received_action: ActionInformation) -> ActionInformation:
+    """Handle a received action from the controlling host."""
+    response_action = ActionInformation(
+        command=received_action.command,
+        parameters={
+            "output": f"received: {received_action.parameters['input']}",
+            "complete": True,
+        },
+        message_id=received_action.message_id,
+    )
+    return response_action
+
+
+def did_handle_message(received_action: ActionInformation) -> None:
+    """Update the node after handling a message."""

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -3,8 +3,11 @@
 from json import dumps, loads
 
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
+from microcontroller import cpu
 
+from snsr import apps
 from snsr.node.classes import (
+    ActionInformation,
     ActionPayload,
     DescriptorInformation,
     SenderInformation,
@@ -38,7 +41,6 @@ def handle_broadcast_message(client: minimqtt.MQTT, action_payload: ActionPayloa
 
 def handle_identify(client: minimqtt.MQTT) -> None:
     """Respond to the the identify command."""
-    from microcontroller import cpu
     from wifi import radio
 
     context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
@@ -51,27 +53,51 @@ def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload)
     """Respond to a message sent to the command topic for the node."""
     from time import sleep
 
-    from .node.classes import ActionInformation
-    from .node.mqtt import get_result_topic
+    from snsr.node.mqtt import get_result_topic
 
     node_context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
     action_information = action_payload.action
+
+    result_information = try_handle_qtpycmd_message(action_information)
+    snsr_app_name = ""
+    if not result_information:
+        snsr_app_name = action_information.command.split(" ")[0]
+        handle_message = apps.get_handler(snsr_app_name)
+        result_information = handle_message(action_information)
+
     descriptor_topic = get_descriptor_topic(node_context["node_group"], node_context["node_identifier"])
     sender = build_sender_information(descriptor_topic)
-    result_payload = ActionPayload(
-        action=ActionInformation(
-            command=action_information.command,
-            parameters={
-                "output": f"received: {action_information.parameters['input']}",
-                "complete": True,
-            },
-            message_id=action_information.message_id,
-        ),
-        sender=sender,
-    )
+    result_payload = ActionPayload(result_information, sender)
     result_topic = get_result_topic(node_context["node_group"], node_context["node_identifier"])
     client.publish(result_topic, dumps(result_payload.as_dict()))
     sleep(0.2)  # Allow the backend to send the message
+
+    did_handle_message = apps.get_handler_completion(snsr_app_name)
+    did_handle_message(action_information)
+
+
+def try_handle_qtpycmd_message(action_information: ActionInformation) -> None | ActionInformation:
+    """Handle the action if it is a 'qtpycmd' system action. Return None otherwise."""
+    if action_information.command == "custom" and action_information.parameters["input"].startswith("qtpycmd "):
+        system_command = action_information.parameters["input"]
+        parts = system_command.split(" ")
+        verb = parts[1]
+        if verb == "get_apps":
+            return handle_get_apps(action_information)
+    return None
+
+
+def handle_get_apps(received_action: ActionInformation) -> ActionInformation:
+    """Handle the 'qtpycmd get_apps' action."""
+    response_action = ActionInformation(
+        command=received_action.parameters["input"],
+        parameters={
+            "output": apps.get_catalog(),
+            "complete": True,
+        },
+        message_id=received_action.message_id,
+    )
+    return response_action
 
 
 def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:
@@ -123,9 +149,7 @@ def build_sender_information(descriptor_topic: str) -> SenderInformation:
     from gc import mem_alloc, mem_free
     from time import monotonic
 
-    from microcontroller import cpu
-
-    from snsr.node.classes import SenderInformation, StatusInformation
+    from snsr.node.classes import StatusInformation
 
     used_bytes = mem_alloc()
     free_bytes = mem_free()


### PR DESCRIPTION
## Summary

This PR adds an `apps` submodule to the snsr node. The module lists available apps and dynamically dispatches messages to them.

## Design

- Add new submodule named `apps`
  - Use `get_catalog()` to see the available apps on the node
  - Use `get_handler()` to look up an app's message handler
  - Use `get_handler_completion()` to look up an app's optional completion
- Sending "qtpycmd get_apps" lists the apps on the node
- By default, use the echo app
- Apps have two APIs to implement
  - handle_message() -- respond to a message
  - did_handle_message() -- an optional completion

## Screenshots or logs

<img width="639" height="850" alt="image" src="https://github.com/user-attachments/assets/3aaa9452-b3d5-4ca9-ba13-9d8dc5b0d616" />

## Testing

See screenshot above
- The echo app repeats what the node receives
- Sending `qtpycmd get_apps` shows the available apps on the node

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
