### PR TITLE
Node: Add retries to main run loop

### DIFF
--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -1,6 +1,8 @@
 """code.py file is the main loop from qtpy_datalogger.sensor_node."""  # noqa: INP001 -- this is the entry point for CircuitPython devices
 
+from gc import collect
 from time import monotonic, sleep
+from traceback import print_exception
 
 from microcontroller import cpu
 from snsr.core import get_memory_info, paint_uart_line, read_one_uart_line
@@ -17,25 +19,60 @@ mqtt_topics = [
     f"qtpy/v1/{settings.node_group}/{node_identifier}/command",
 ]
 
-radio = connect_to_wifi()
-mqtt_client = create_mqtt_client(radio, settings.node_group, node_identifier)
-connect_and_subscribe(mqtt_client, mqtt_topics)
 
-response = ""
-while response.lower() not in ["exit", "quit"]:
-    uptime = monotonic() - settings.boot_time
-    paint_uart_line(f"  {uptime:>12.3f}    Poll UART     [ Poll MQTT ]     ")
-    mqtt_client.loop()
+def main_loop() -> str:
+    """Run the main node loop."""
+    radio = connect_to_wifi()
+    mqtt_client = create_mqtt_client(radio, settings.node_group, node_identifier)
+    connect_and_subscribe(mqtt_client, mqtt_topics)
 
-    uptime = monotonic() - settings.boot_time
-    paint_uart_line(f"  {uptime:>12.3f}  [ Poll UART ]     Poll MQTT       ")
-    sleep(0.2)
-    if runtime.usb_connected and runtime.serial_connected and runtime.serial_bytes_available > 0:
-        print()  # noqa: T201 -- use direct IO for user REPL
-        response = read_one_uart_line()
-        if not response:
+    response = ""
+    while response.lower() not in ["exit", "quit"]:
+        if runtime.usb_connected and runtime.serial_connected:
+            uptime = monotonic() - settings.boot_time
+            paint_uart_line(f"  {uptime:>12.3f}    Poll UART     [ Poll MQTT ]     ")
+        did_receive = mqtt_client.loop(timeout=1.0)  # Smallest supported timeout
+        if not (did_receive or runtime.serial_connected):
+            sleep(4)  # Conserve battery by not constantly polling the network
+
+        if runtime.usb_connected and runtime.serial_connected:
+            uptime = monotonic() - settings.boot_time
+            paint_uart_line(f"  {uptime:>12.3f}  [ Poll UART ]     Poll MQTT       ")
+            sleep(0.2)
+            if not runtime.serial_bytes_available:
+                continue
+            print()  # noqa: T201 -- use direct IO for user REPL
             response = read_one_uart_line()
-        used_kb, free_kb = get_memory_info()
-        print(f"Received '{response}' with {used_kb} / {free_kb}  (used/free)")  # noqa: T201 -- use direct IO for user REPL
+            if not response:
+                response = read_one_uart_line()
+            used_kb, free_kb = get_memory_info()
+            print(f"Received '{response}' with {used_kb} / {free_kb}  (used/free)")  # noqa: T201 -- use direct IO for user REPL
 
-unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
+    unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
+    return response
+
+
+most_recent_error = type(None)
+error_count = 0
+error_limit = 3
+while True:
+    print("Entering root loop")  # noqa: T201 -- use direct IO for user REPL
+    try:
+        result = main_loop()
+        if result.lower() in ["exit", "quit"]:
+            print("Exiting to REPL...")  # noqa: T201 -- use direct IO for user REPL
+            break
+    except Exception as e:
+        print()  # noqa: T201 -- use direct IO for user REPL
+        print(f"Encountered {type(e)} {e.args}")  # noqa: T201 -- use direct IO for user REPL
+        print_exception(e)
+        collect()
+        if type(e) is most_recent_error:
+            error_count = error_count + 1
+            if error_count >= error_limit:
+                raise
+        else:
+            most_recent_error = type(e)
+            error_count = 0
+        print("Trying again...")  # noqa: T201 -- use direct IO for user REPL
+        continue


### PR DESCRIPTION
## Summary

This PR adds a retry mechanism to the main snsr node run loop.

When an exception happens, the node reruns the main loop as long as it has not encountered the same exception type three times. The count resets when the loop detects a different exception to accommodate error mitigation and environmental disruption. On each encounter, the loop prints debug information to the UART port.

Addresses #34

## Design

- Move the run loop to a `main()` function
- Rerun `main()` up to three times for the same exception
- Conserve some energy by only printing to UART when the node detects USB connected

## Screenshots or logs

<img width="641" height="852" alt="image" src="https://github.com/user-attachments/assets/c6c64a43-c4bb-43bc-9167-e39da7c7bd74" />

## Testing

- The node connects to the MQTT broker
- The node responds to messages and commands

## Checklist

- [x] Issues linked / labels applied
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
