### PR TITLE
equip CLI command: Print newer files in sorted order

### DIFF
--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -291,7 +291,7 @@ def _format_bundle_comparison(
     report_lines = report_contents.splitlines()
 
     newer_files = set()
-    for path, freshness in file_freshness.items():
+    for path, freshness in sorted(file_freshness.items()):
         full_path = this_bundle.device_files[0].joinpath(path)
         if not full_path.is_file():
             continue
@@ -378,7 +378,7 @@ def _equip_snsr_node(behavior: Behavior, comparison_information: dict[str, SnsrN
         )
         older_files = set()
         newer_files = set()
-        for path, freshness in runtime_freshness.items():
+        for path, freshness in sorted(runtime_freshness.items()):
             full_path = this_bundle.device_files[0].joinpath(path)
             if not full_path.is_file():
                 continue


### PR DESCRIPTION
## Summary

This PR is updates the `equip` command to print the newer files in sorted order.

## Design

- Use `sorted()` when iterating over the file comparison report

## Screenshots or logs

### Before

```
INFO     Installing sensor_node v0.1.0.post0.dev0 to 'E:\'
INFO       Newer: snsr\node\classes.py
INFO       Newer: snsr\apps\__init__.py
INFO       Newer: snsr\handlers.py
INFO       Newer: snsr\rxtx.py
INFO       Newer: snsr\pysh\linebuffer.py
INFO       Newer: snsr\core.py
INFO       Newer: snsr\pysh\py_shell.py
INFO       Newer: snsr\__init__.py
INFO       Newer: code.py
INFO       Newer: snsr\apps\soil_swell.py
INFO       Newer: snsr\pysh\diagnostics.py
INFO       Newer: snsr\pysh\__init__.py
INFO       Newer: snsr\apps\echo.py
INFO       Newer: snsr\node\__init__.py
INFO       Newer: snsr\node\mqtt.py
INFO       Newer: snsr\notice.toml
INFO       Newer: snsr\settings.py
INFO     Bundle files updated
```

### After

```
INFO     Installing sensor_node v0.1.0.post0.dev0 to 'E:\'
INFO       Newer: code.py
INFO       Newer: snsr\__init__.py
INFO       Newer: snsr\apps\__init__.py
INFO       Newer: snsr\apps\echo.py
INFO       Newer: snsr\apps\soil_swell.py
INFO       Newer: snsr\core.py
INFO       Newer: snsr\handlers.py
INFO       Newer: snsr\node\__init__.py
INFO       Newer: snsr\node\classes.py
INFO       Newer: snsr\node\mqtt.py
INFO       Newer: snsr\notice.toml
INFO       Newer: snsr\pysh\__init__.py
INFO       Newer: snsr\pysh\diagnostics.py
INFO       Newer: snsr\pysh\linebuffer.py
INFO       Newer: snsr\pysh\py_shell.py
INFO       Newer: snsr\rxtx.py
INFO       Newer: snsr\settings.py
INFO     Bundle files updated
```

## Testing

See logs above.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
