### PR TITLE
Node API: Switch app design to SnsrApp base class

### DIFF
--- a/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
@@ -1,11 +1,22 @@
 """Matching sensor_node apps for their host-side qtpy_datalogger.apps."""
 
-try:  # noqa: SIM105 -- contextlib is not available for CircuitPython
-    from collections.abc import Callable
-except ImportError:
-    pass
-
 from snsr.node.classes import ActionInformation
+
+
+class SnsrApp:
+    """Base class for sensor_node apps."""
+
+    def __init__(self, action_information: ActionInformation) -> None:
+        """Initialize a new SnsrApp."""
+        self.action = action_information
+
+    def handle_message(self) -> ActionInformation:
+        """Handle a received action from the controlling host."""
+        raise NotImplementedError()
+
+    def did_handle_message(self) -> None:
+        """Update the node after handling a message."""
+        raise NotImplementedError()
 
 
 def get_catalog() -> list[str]:
@@ -17,15 +28,15 @@ def get_catalog() -> list[str]:
     return apps
 
 
-def get_handler(snsr_app_name: str) -> Callable[[ActionInformation], ActionInformation]:
-    """Return the handler that matches snsr_app_name."""
-    from snsr.apps import echo
+def get_app(received_action: ActionInformation) -> SnsrApp:
+    """Return the sensor_node app that matches received_action."""
+    snsr_app_name = received_action.command.split(" ")[0]
+    if snsr_app_name == "custom" and received_action.parameters["input"].startswith("qtpycmd "):
+        from snsr.apps.qtpycmd import QtpyCmdApp
 
-    return echo.handle_message
+        return QtpyCmdApp(received_action)
 
+    # Fallback to echo app handler
+    from snsr.apps.echo import EchoApp
 
-def get_handler_completion(snsr_app_name: str) -> Callable[[ActionInformation], None]:
-    """Return the completion that matches snsr_app_name."""
-    from snsr.apps import echo
-
-    return echo.did_handle_message
+    return EchoApp(received_action)

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
@@ -1,20 +1,24 @@
 """Simple 'echo' app that repeats every message received."""
 
+from snsr.apps import SnsrApp
 from snsr.node.classes import ActionInformation
 
 
-def handle_message(received_action: ActionInformation) -> ActionInformation:
-    """Handle a received action from the controlling host."""
-    response_action = ActionInformation(
-        command=received_action.command,
-        parameters={
-            "output": f"received: {received_action.parameters['input']}",
-            "complete": True,
-        },
-        message_id=received_action.message_id,
-    )
-    return response_action
+class EchoApp(SnsrApp):
+    """Repeat every message received."""
 
+    def handle_message(self) -> ActionInformation:
+        """Handle a received action from the controlling host."""
+        echo = self.action.parameters.get("input", self.action.command)
+        response_action = ActionInformation(
+            command=self.action.command,
+            parameters={
+                "output": f"received: {echo}",
+                "complete": True,
+            },
+            message_id=self.action.message_id,
+        )
+        return response_action
 
-def did_handle_message(received_action: ActionInformation) -> None:
-    """Update the node after handling a message."""
+    def did_handle_message(self) -> None:
+        """Update the node after handling a message."""

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -1,0 +1,40 @@
+"""App that queries and demonstrates board resources like IO pins."""
+
+from snsr.apps import SnsrApp
+from snsr.node.classes import ActionInformation
+
+
+class QtpyCmdApp(SnsrApp):
+    """Respond to 'custom' commands that start with 'qtpycmd '."""
+
+    def handle_message(self) -> ActionInformation:
+        """Handle a received action from the controlling host."""
+        system_command = self.action.parameters["input"]
+        parts = system_command.split(" ")
+        verb = parts[1]
+        if verb == "get_apps":
+            return handle_get_apps(self.action)
+
+        # Fallback to echo app
+        from snsr.apps.echo import EchoApp
+
+        echo = EchoApp(self.action)
+        return echo.handle_message()
+
+    def did_handle_message(self) -> None:
+        """Update the node after handling a message."""
+
+
+def handle_get_apps(received_action: ActionInformation) -> ActionInformation:
+    """Handle the 'qtpycmd get_apps' action."""
+    from snsr.apps import get_catalog
+
+    response_action = ActionInformation(
+        command=received_action.parameters["input"],
+        parameters={
+            "output": get_catalog(),
+            "complete": True,
+        },
+        message_id=received_action.message_id,
+    )
+    return response_action

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -7,7 +7,6 @@ from microcontroller import cpu
 
 from snsr import apps
 from snsr.node.classes import (
-    ActionInformation,
     ActionPayload,
     DescriptorInformation,
     SenderInformation,
@@ -35,7 +34,7 @@ def handle_broadcast_message(client: minimqtt.MQTT, action_payload: ActionPayloa
         handle_identify(client)
         return
 
-    # Fallback: forward to node as a command
+    # Fallback: forward to node as a command for retained group messages
     handle_command_message(client, action_payload)
 
 
@@ -56,48 +55,21 @@ def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload)
     from snsr.node.mqtt import get_result_topic
 
     node_context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
+    node_group = node_context["node_group"]
+    node_identifier = node_context["node_identifier"]
+    result_topic = get_result_topic(node_group, node_identifier)
+    descriptor_topic = get_descriptor_topic(node_group, node_identifier)
     action_information = action_payload.action
 
-    result_information = try_handle_qtpycmd_message(action_information)
-    snsr_app_name = ""
-    if not result_information:
-        snsr_app_name = action_information.command.split(" ")[0]
-        handle_message = apps.get_handler(snsr_app_name)
-        result_information = handle_message(action_information)
+    app = apps.get_app(action_information)
+    result_information = app.handle_message()
 
-    descriptor_topic = get_descriptor_topic(node_context["node_group"], node_context["node_identifier"])
     sender = build_sender_information(descriptor_topic)
     result_payload = ActionPayload(result_information, sender)
-    result_topic = get_result_topic(node_context["node_group"], node_context["node_identifier"])
     client.publish(result_topic, dumps(result_payload.as_dict()))
-    sleep(0.2)  # Allow the backend to send the message
+    sleep(0.2)  # Allow the backend to send the message before invoking the completion which may sleep
 
-    did_handle_message = apps.get_handler_completion(snsr_app_name)
-    did_handle_message(action_information)
-
-
-def try_handle_qtpycmd_message(action_information: ActionInformation) -> None | ActionInformation:
-    """Handle the action if it is a 'qtpycmd' system action. Return None otherwise."""
-    if action_information.command == "custom" and action_information.parameters["input"].startswith("qtpycmd "):
-        system_command = action_information.parameters["input"]
-        parts = system_command.split(" ")
-        verb = parts[1]
-        if verb == "get_apps":
-            return handle_get_apps(action_information)
-    return None
-
-
-def handle_get_apps(received_action: ActionInformation) -> ActionInformation:
-    """Handle the 'qtpycmd get_apps' action."""
-    response_action = ActionInformation(
-        command=received_action.parameters["input"],
-        parameters={
-            "output": apps.get_catalog(),
-            "complete": True,
-        },
-        message_id=received_action.message_id,
-    )
-    return response_action
+    app.did_handle_message()
 
 
 def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:


### PR DESCRIPTION
## Summary

This PR changes the design pattern for apps on the sensor node. Rather than module-level functions for each, use a base class named `SnsrApp` to handle MQTT messages.

- Simpler chain-of-command pattern
- **Fewer** CPU instructions and _same_ RAM allocated

```python
# Get an app that can handle the action
app = apps.get_app(action_information)

# Ask the app to handle it and then send its reponse
result_information = app.handle_message()
...
mqtt_client.publish(result_topic, result_payload)

# Ask the app to finalize its work
app.did_handle_message()
```

## Design

- Add a new class named `SnsrApp` with two required overrides
  - `handle_message()` and `did_handle_message()`
  - Accept the `ActionInformation` for the app in the `__init__()`
- Replace the get-handler functions with a `get_app()` function
- Rework the `echo` app to use the new base class
- Extract the `qtpycmd` handlers to a new app named `QtpyCmdApp`

## Screenshots or logs

Collected messages with the Scanner app

### Before

```
⬛ hello
⬅ received: hello
⬜ with 52336 bytes used, 60496 bytes remaining, at temperature 45.4 degC
⬛ qtpycmd
⬅ received: qtpycmd
⬜ with 61328 bytes used, 51504 bytes remaining, at temperature 45.4 degC
⬛ qtpycmd 
⬅ received: qtpycmd 
⬜ with 57072 bytes used, 55760 bytes remaining, at temperature 45.4 degC
⬛ qtpycmd get_apps
⬅ ['echo']
⬜ with 53504 bytes used, 59328 bytes remaining, at temperature 45.4 degC
```

### After

```
⬛ 2 hello 2
⬅ received: 2 hello 2
⬜ with 52368 bytes used, 60464 bytes remaining, at temperature 45.4 degC
⬛ 2 qtpycmd 2
⬅ received: 2 qtpycmd 2
⬜ with 53248 bytes used, 59584 bytes remaining, at temperature 45.4 degC
⬛ 2 qtpycmd 2
⬅ received: 2 qtpycmd 2
⬜ with 55440 bytes used, 57392 bytes remaining, at temperature 45.4 degC
⬛ qtpycmd get_apps
⬅ ['echo', 'qtpycmd']
⬜ with 53488 bytes used, 59344 bytes remaining, at temperature 45.4 degC
```

## Testing

- The sensor responds to messages from the Scanner app

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
