### PR TITLE
connect CLI: Improve reconnect message for nodes not auto-discovered via MQTT

### DIFF
--- a/src/qtpy_datalogger/discovery.py
+++ b/src/qtpy_datalogger/discovery.py
@@ -25,7 +25,7 @@ from serial.tools import miniterm as mt
 
 from qtpy_datalogger import network
 
-from .datatypes import CaptionCorrections, ConnectionTransport, DetailKey, ExitCode, SnsrNotice, SnsrPath
+from .datatypes import CaptionCorrections, ConnectionTransport, Default, DetailKey, ExitCode, SnsrNotice, SnsrPath
 
 logger = logging.getLogger(__name__)
 
@@ -120,8 +120,9 @@ def handle_connect(behavior: Behavior, group_id: str, node: str, port: str) -> N
         open_session_on_port(port)
     elif communication_transport == ConnectionTransport.MQTT_WiFi:
         network.open_session_on_node(group_id, node)
+        group_option = "" if group_id == Default.MqttGroup else f"--group {group_id}"
         logger.info("")
-        logger.info(f"Reconnect with 'qtpy-datalogger connect --node {node}'")
+        logger.info(f"Reconnect with 'qtpy-datalogger connect {group_option} --node {node}'")
 
 
 async def discover_qtpy_devices_async(group_id: str) -> dict[str, QTPyDevice]:


### PR DESCRIPTION
## Summary

This PR makes the reconnect message printed by `qtpy-datalogger connect` show enough information to reconnect to a node that cannot be auto-discovered. The most common scenario is when the node is connected via MQTT but uses a custom group name.

## Design

Update the message to print the `--group GROUP` option in the message on disconnect.

## Screenshots or logs

**`qtpy-datalogger connect --group zone2`**
```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group 'zone2'
INFO     Identifying QT Py devices
INFO     QT Py device 'Adafruit QT Py ESP32-S3 no PSRAM' has UART and MQTT available, select a connection transport to continue
  1:  MQTT  (WiFi)
  2:  UART  (serial)
Enter a transport number (1, 2): 1
INFO     User-selected 'Adafruit QT Py ESP32-S3 no PSRAM' as MQTT node 'node-42cea4d12c8b-0' on '192.168.0.12'
Use any of 'exit' or 'quit' to exit.
node-42cea4d12c8b-0 > hello
Received 'received: hello' from node with 115.563 kB used, 39.313 kB remaining, at temperature 44.4 degC
node-42cea4d12c8b-0 > quit

INFO     Reconnect with 'qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0'
```

## Testing

See logs above

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
