### PR TITLE
Node API: Add system details, IO resources, and volatile settings for apps to Settings singleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,18 @@ ignore = [
 "src/qtpy_datalogger/apps/empty.py" = [
     "F401",
 ]
+# Disable rules
+# - Some Python libraries are not available on CircuitPython
+# - Some design pattern deviations are expected
 "src/qtpy_datalogger/sensor_node/**.py" = [
-    "PLC0415",
+    "INP001",       # No __init__.py because code.py is the entry point
+    "PLC0415",      # Allow non-toplevel imports to conserve memory
+    "PLR2004",      # Allow "magic number" literals to conserve memory
+    "PTH116",       # Path.stat() is not available
+    "PTH123",       # Path.open() is not available
+    "PTH208",       # Path.iterdir() is not available
+    "SIM105",       # contextlib is not available
+    "T201",         # Use direct IO for user REPL
 ]
 
 [build-system]

--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -461,12 +461,12 @@ class ScannerApp(guikit.AsyncWindow):
                     )
                     response_complete = response_parameters["complete"]
                     response = response_parameters["output"]
-                    used_bytes = sender_information.status.used_memory
-                    free_bytes = sender_information.status.free_memory
+                    used_kb = sender_information.status.used_memory
+                    free_kb = sender_information.status.free_memory
                     cpu_degc = sender_information.status.cpu_temperature
                     self.append_text_to_log(f"{received_emoji} {response}\n")
                     self.append_text_to_log(
-                        f"{status_emoji} with {used_bytes} bytes used, {free_bytes} bytes remaining, at temperature {cpu_degc} degC\n"
+                        f"{status_emoji} with {used_kb} kB used, {free_kb} kB remaining, at temperature {cpu_degc} degC\n"
                     )
                 except TimeoutError:
                     new_status_message = (

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -1,4 +1,4 @@
-"""code.py file is the main loop from qtpy_datalogger.sensor_node."""  # noqa: INP001 -- this is the entry point for CircuitPython devices
+"""code.py file is the main loop from qtpy_datalogger.sensor_node."""
 
 from gc import collect
 from time import monotonic, sleep
@@ -11,9 +11,9 @@ from snsr.settings import settings
 from supervisor import runtime
 
 settings.boot_time = monotonic()
-print(f"Booted at {settings.boot_time:.3f}")  # noqa: T201 -- use direct IO for user REPL
+print(f"Booted at {settings.boot_time:.3f}")
 
-node_identifier = f"node-{cpu.uid.hex().lower()}-0"  # Matches boot_out.txt
+node_identifier = f"node-{cpu.uid.hex().lower()}-0"  # Lower case matches boot_out.txt
 mqtt_topics = [
     f"qtpy/v1/{settings.node_group}/broadcast",
     f"qtpy/v1/{settings.node_group}/{node_identifier}/command",
@@ -41,12 +41,12 @@ def main_loop() -> str:
             sleep(0.2)
             if not runtime.serial_bytes_available:
                 continue
-            print()  # noqa: T201 -- use direct IO for user REPL
+            print()
             response = read_one_uart_line()
             if not response:
                 response = read_one_uart_line()
             used_kb, free_kb = get_memory_info()
-            print(f"Received '{response}' with {used_kb} / {free_kb}  (used/free)")  # noqa: T201 -- use direct IO for user REPL
+            print(f"Received '{response}' with {used_kb} / {free_kb}  (used/free)")
 
     unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
     return response
@@ -56,15 +56,15 @@ most_recent_error = type(None)
 error_count = 0
 error_limit = 3
 while True:
-    print("Entering root loop")  # noqa: T201 -- use direct IO for user REPL
+    print("Entering root loop")
     try:
         result = main_loop()
         if result.lower() in ["exit", "quit"]:
-            print("Exiting to REPL...")  # noqa: T201 -- use direct IO for user REPL
+            print("Exiting to REPL...")
             break
     except Exception as e:
-        print()  # noqa: T201 -- use direct IO for user REPL
-        print(f"Encountered {type(e)} {e.args}")  # noqa: T201 -- use direct IO for user REPL
+        print()
+        print(f"Encountered {type(e)} {e.args}")
         print_exception(e)
         collect()
         if type(e) is most_recent_error:
@@ -74,5 +74,5 @@ while True:
         else:
             most_recent_error = type(e)
             error_count = 0
-        print("Trying again...")  # noqa: T201 -- use direct IO for user REPL
+        print("Trying again...")
         continue

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
@@ -23,7 +23,7 @@ def get_catalog() -> list[str]:
     """Return a list of the selectable apps."""
     from os import listdir
 
-    files = listdir(str(__path__))  # noqa: PTH208 -- pathlib not available on CircuitPython
+    files = listdir(str(__path__))
     apps = [file.split(".")[0] for file in files if not file.startswith("__init__")]
     return apps
 

--- a/src/qtpy_datalogger/sensor_node/snsr/core.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/core.py
@@ -50,7 +50,7 @@ def get_memory_info() -> tuple[str, str]:
 def get_notice_info() -> dict:
     """Return a serializable representation of the notice.toml file."""
     notice_contents = []
-    with open("/snsr/notice.toml") as notice_toml:  # noqa: PTH123 -- Path.open() is not available on CircuitPython
+    with open("/snsr/notice.toml") as notice_toml:
         notice_contents = notice_toml.read().splitlines()
     notice_info = {}
     for line in notice_contents:

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -118,17 +118,16 @@ def build_descriptor_information(role: str, serial_number: str, ip_address: str)
 
 def build_sender_information(descriptor_topic: str) -> SenderInformation:
     """Return a SenderInformation instance describing the client's current state."""
-    from gc import mem_alloc, mem_free
     from time import monotonic
 
     from snsr.node.classes import StatusInformation
 
-    used_bytes = mem_alloc()
-    free_bytes = mem_free()
+    used_kb = settings.used_kb
+    free_kb = settings.free_kb
     cpu_celsius = cpu.temperature
     monotonic_time = monotonic()
     status = StatusInformation(
-        used_memory=str(used_bytes), free_memory=str(free_bytes), cpu_temperature=str(cpu_celsius)
+        used_memory=str(used_kb), free_memory=str(free_kb), cpu_temperature=str(cpu_celsius)
     )
     sender = SenderInformation(descriptor_topic=descriptor_topic, sent_at=str(monotonic_time), status=status)
     return sender

--- a/src/qtpy_datalogger/sensor_node/snsr/node/mqtt.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/node/mqtt.py
@@ -60,7 +60,7 @@ def get_result_topic(group_id: str, node_id: str) -> str:
 def node_from_topic(topic: str) -> str:
     """Return the node_id from the specified topic. Return an empty string if the topic is a group topic."""
     parts = topic.split("/")
-    if len(parts) < 5:  # noqa: PLR2004 -- do not name this constant until it needs to be shared
+    if len(parts) < 5:
         # Group-level topic like 'qtpy/v1/{group_id}/broadcast'
         return ""
     return parts[3]

--- a/src/qtpy_datalogger/sensor_node/snsr/pysh/diagnostics.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/pysh/diagnostics.py
@@ -134,7 +134,7 @@ class TracedSession:
         """Prompt the user for input with the given message."""
         response = self._session.prompt(message)
         if self._autoecho and self._tracer.traced_io_log:
-            _ = [print(entry) for entry in self._tracer.traced_io_log]  # noqa: T201 -- use builtin to bypass self-tracing
+            _ = [print(entry) for entry in self._tracer.traced_io_log]
             self._tracer.clear_log()
         return response.encode("UTF-8")
 
@@ -147,7 +147,7 @@ class TracedSession:
 def is_printable(char_ord: int) -> bool:
     """Return true if the specified ordinal is printable in a terminal."""
     # https://ss64.com/ascii.html
-    return char_ord > 31 and char_ord < 127  # noqa: PLR2004 -- ordinals /are/ magic numbers
+    return char_ord > 31 and char_ord < 127
 
 
 def debug_str(in_ordinal: int) -> str:

--- a/src/qtpy_datalogger/sensor_node/snsr/pysh/py_shell.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/pysh/py_shell.py
@@ -4,7 +4,7 @@
 
 from .linebuffer import LineBuffer
 
-try:  # noqa: SIM105 -- contextlib is not available for CircuitPython
+try:
     from typing import BinaryIO
 except ImportError:
     pass
@@ -239,7 +239,7 @@ def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- we need many lines an
     """Track and handle the control codes as they are read."""
     control_codes.append(in_ord)
     control_command_length = len(control_codes)
-    if control_command_length == 2:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning
+    if control_command_length == 2:
         if control_codes[0] == _ORD_ESC and in_ord == _ORD_OPEN_BRACKET:
             # Begin escape control sequence, assume cursor move until further reads show otherwise
             control_pattern = _CONTROL_PATTERN_MOVE_CURSOR_KEY
@@ -249,7 +249,7 @@ def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- we need many lines an
         else:
             # No handlers for other command sequences
             control_codes.clear()
-    elif control_command_length == 3:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning
+    elif control_command_length == 3:
         if control_pattern == _CONTROL_PATTERN_MOVE_CURSOR_KEY:
             if ord("0") <= in_ord <= ord("9"):
                 # We read more and learned we're reading an editor command
@@ -280,7 +280,7 @@ def _process_control_sequence(  # noqa: PLR0912 PLR0915 -- we need many lines an
             else:
                 # No handlers for lower F-key codes
                 pass
-    elif control_command_length == 4:  # noqa: PLR2004 -- this magic number is used as a length, has no separate meaning
+    elif control_command_length == 4:
         if control_pattern == _CONTROL_PATTERN_EDITOR_KEY:
             if in_ord == _ORD_TILDE:
                 if control_codes[2:-1] == [ord("3")]:

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -13,14 +13,13 @@ from snsr.settings import settings
 
 def connect_to_wifi() -> wifi.Radio:
     """Connect to the SSID from settings.toml and return the radio instance."""
-    wifi.radio.enabled = True
-    wifi.radio.connect(settings.wifi_ssid, settings.wifi_password)
+    settings.connect_to_wifi()
     return wifi.radio
 
 
 def disconnect_from_wifi(wifi: wifi.Radio) -> None:
     """Disconnect and disable the WiFi radio."""
-    wifi.enabled = False
+    settings.disconnect_from_wifi()
 
 
 def format_wifi_information(wifi: wifi.Radio) -> list[str]:

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -5,6 +5,8 @@ import board
 import busio
 import digitalio
 import neopixel
+import wifi
+from adafruit_connection_manager import connection_manager_close_all
 
 
 class Settings:
@@ -25,8 +27,6 @@ class Settings:
             return
         self._initialize_from_env()
         self._initialize_dynamic_settings()
-        self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
-        self._stemma_bus = None
         self._initialized = True
 
     def _initialize_from_env(self) -> None:
@@ -42,16 +42,9 @@ class Settings:
     def _initialize_dynamic_settings(self) -> None:
         """Initialize the read-write settings."""
         self._boot_time = -1.0
-
-    @property
-    def wifi_ssid(self) -> str:
-        """Return the WiFi SSID from the settings.toml file."""
-        return self._wifi_ssid
-
-    @property
-    def wifi_password(self) -> str:
-        """Return the WiFi password from the settings.toml file."""
-        return self._wifi_password
+        self._wifi_radio = None
+        self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
+        self._stemma_bus = None
 
     @property
     def mqtt_broker(self) -> str:
@@ -77,6 +70,31 @@ class Settings:
     def boot_time(self, new_boot_time: float) -> None:
         """Set a new value for the node's boot time."""
         self._boot_time = new_boot_time
+
+    def connect_to_wifi(self) -> None:
+        """Connect to the SSID from settings.toml and return the radio instance."""
+        wifi.radio.enabled = True
+        wifi.radio.connect(settings._wifi_ssid, settings._wifi_password)
+        self._wifi_radio = wifi.radio
+
+    @property
+    def wifi_radio(self) -> wifi.Radio:
+        """Return the WiFi radio instance."""
+        the_radio = self._wifi_radio
+        if not the_radio:
+            raise ConnectionError()
+        return the_radio
+
+    @property
+    def ip_address(self) -> str:
+        """Return the IP address of the sensor_node."""
+        return str(self.wifi_radio.ipv4_address)
+
+    def disconnect_from_wifi(self) -> None:
+        """Disconnect and disable the WiFi radio."""
+        self._wifi_radio = None
+        connection_manager_close_all()
+        wifi.radio.enabled = False
 
     def get_neopixel(self) -> neopixel.NeoPixel:
         """Return the NeoPixel on the board."""

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -128,7 +128,7 @@ class Settings:
 
     @property
     def uptime(self) -> float:
-        """Return the time since the last code.py start in seconds."""
+        """Return the time in seconds since the last code.py launch."""
         return monotonic() - settings.boot_time
 
     @property
@@ -158,7 +158,7 @@ class Settings:
 
     @property
     def boot_time(self) -> float:
-        """Return the node's time since boot in milliseconds."""
+        """Return the time in seconds since the node booted."""
         return self._boot_time
 
     @boot_time.setter
@@ -167,14 +167,14 @@ class Settings:
         self._boot_time = new_boot_time
 
     def connect_to_wifi(self) -> None:
-        """Connect to the SSID from settings.toml and return the radio instance."""
+        """Connect to the SSID from settings.toml."""
         wifi.radio.enabled = True
         wifi.radio.connect(settings._wifi_ssid, settings._wifi_password)
         self._wifi_radio = wifi.radio
 
     @property
     def wifi_radio(self) -> wifi.Radio:
-        """Return the WiFi radio instance."""
+        """Return the WiFi radio instance. Raises ConnectionError when disconnected."""
         the_radio = self._wifi_radio
         if not the_radio:
             raise ConnectionError()
@@ -182,7 +182,7 @@ class Settings:
 
     @property
     def ip_address(self) -> str:
-        """Return the IP address of the sensor_node."""
+        """Return the IP address of the sensor_node. Raises ConnectionError when disconnected."""
         return str(self.wifi_radio.ipv4_address)
 
     def disconnect_from_wifi(self) -> None:
@@ -217,7 +217,7 @@ class Settings:
         return analog_input
 
     def get_dio_pin(self, pin_name: str) -> digitalio.DigitalInOut:
-        """Initialize the digital io pin instance that matches the board's pin_name."""
+        """Initialize the digital IO pin instance that matches the board's pin_name."""
         if pin_name not in self._board_io_pins:
             self._board_io_pins[pin_name] = digitalio.DigitalInOut(getattr(board, pin_name))
         digital_io = self._board_io_pins[pin_name]
@@ -239,7 +239,7 @@ class Settings:
         return self._stemma_bus
 
     def get_app_settings(self, app_name: str) -> dict:
-        """Get the settings for app_name."""
+        """Get the settings for app_name. Use update_app_settings() to make changes."""
         return self._settings_for_app_name.get(app_name, {})
 
     def update_app_settings(self, app_name: str, settings: dict) -> None:
@@ -250,7 +250,7 @@ class Settings:
 
 
 def get_notice_info() -> NoticeInformation:
-    """Return a serializable representation of the notice.toml file."""
+    """Return a NoticeInformation representation of the notice.toml file."""
     notice_contents = []
     with open("/snsr/notice.toml") as notice_toml:
         notice_contents = notice_toml.read().splitlines()

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -64,6 +64,7 @@ class Settings:
     def _initialize_dynamic_settings(self) -> None:
         """Initialize the read-write settings."""
         self._boot_time = -1.0
+        self._app_catalog = None  # Lazily loaded on first access
         self._wifi_radio = None
         self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
         self._stemma_bus = None
@@ -99,6 +100,13 @@ class Settings:
     def mqtt_client_id(self) -> str:
         """Return the unique MQTT client ID for the sensor_node."""
         return self._mqtt_client_id
+
+    @property
+    def app_catalog(self) -> list[str]:
+        """Return the apps on the sensor_node."""
+        if not self._app_catalog:
+            self._app_catalog = discover_apps()
+        return self._app_catalog
 
     @property
     def cpu_temperature(self) -> float:
@@ -242,6 +250,23 @@ def get_notice_info() -> NoticeInformation:
         value = key_and_value[1].strip().replace('"', "")
         notice_info[key] = value
     return NoticeInformation.from_dict(notice_info)
+
+
+def discover_apps() -> list[str]:
+    """Autodetect apps on the sensor_node and return a list of names."""
+    from os import listdir, stat
+
+    plain_file_stat = 0x8000
+    files = listdir("/snsr/apps")  # noqa: PTH208 -- pathlib not available on CircuitPython
+    apps = []
+    for file in files:
+        if file.startswith("__init__"):
+            continue
+        if stat(f"/snsr/apps/{file}")[0] != plain_file_stat:  # noqa: PTH116 -- pathlib not available on CircuitPython
+            continue
+        app_basename = file.split(".")[0]
+        apps.append(app_basename)
+    return apps
 
 
 def format_wifi_information(wifi_radio: wifi.Radio) -> list[str]:

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -1,5 +1,8 @@
 """Global settings used by the sensor_node runtime."""
 
+import gc
+from time import monotonic
+
 import analogio
 import board
 import busio
@@ -7,6 +10,8 @@ import digitalio
 import neopixel
 import wifi
 from adafruit_connection_manager import connection_manager_close_all
+from microcontroller import cpu
+from supervisor import runtime
 
 
 class Settings:
@@ -45,6 +50,38 @@ class Settings:
         self._wifi_radio = None
         self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
         self._stemma_bus = None
+
+    @property
+    def cpu_temperature(self) -> float:
+        """Return the temperature of the CPU in degrees C."""
+        if not cpu.temperature:
+            return 0.0
+        return cpu.temperature
+
+    @property
+    def used_kb(self) -> float:
+        """Return the used memory in kB."""
+        return gc.mem_alloc() / 1024.0
+
+    @property
+    def free_kb(self) -> float:
+        """Return the free memory in kB."""
+        return gc.mem_free() / 1024.0
+
+    @property
+    def uptime(self) -> float:
+        """Return the time since the last code.py start in seconds."""
+        return monotonic() - settings.boot_time
+
+    @property
+    def uart_connected(self) -> bool:
+        """Return true if the sensor_node has an open UART connection."""
+        return runtime.usb_connected and runtime.serial_connected
+
+    @property
+    def uart_bytes_waiting(self) -> bool:
+        """Return true if the UART has bytes waiting to be read."""
+        return runtime.serial_bytes_available > 0
 
     @property
     def mqtt_broker(self) -> str:

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -13,6 +13,8 @@ from adafruit_connection_manager import connection_manager_close_all
 from microcontroller import cpu
 from supervisor import runtime
 
+from snsr.node.classes import NoticeInformation
+
 
 class Settings:
     """A singleton that holds the global settings used by the sensor_node runtime."""
@@ -30,9 +32,24 @@ class Settings:
         """Initialize the instance."""
         if self._initialized:
             return
+        self._initialize_constants()
         self._initialize_from_env()
         self._initialize_dynamic_settings()
         self._initialized = True
+
+    def _initialize_constants(self) -> None:
+        """Initialize the readonly settings from the device."""
+        from os import uname
+        from sys import implementation, version_info
+
+        from snsr.node.mqtt import format_mqtt_client_id
+
+        self._board_id = board.board_id
+        self._serial_number = cpu.uid.hex().lower()
+        self._micropython_base = ".".join([str(version_segment) for version_segment in version_info])
+        self._python_implementation = f"{implementation.name}-{uname().release}"
+        self._notice_info = None  # Lazily loaded on first access
+        self._mqtt_client_id = format_mqtt_client_id(role="node", mac_address=self._serial_number, pid=0)
 
     def _initialize_from_env(self) -> None:
         """Initialize the readonly settings from the environment variables."""
@@ -50,6 +67,38 @@ class Settings:
         self._wifi_radio = None
         self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
         self._stemma_bus = None
+
+    @property
+    def board_id(self) -> str:
+        """Return the board identifier for the sensor_node."""
+        return self._board_id
+
+    @property
+    def serial_number(self) -> str:
+        """Return the unique identifier for the sensor_node."""
+        return self._serial_number
+
+    @property
+    def micropython_base(self) -> str:
+        """Return the Python version on the sensor_node."""
+        return self._micropython_base
+
+    @property
+    def python_implementation(self) -> str:
+        """Return the Python implementation on the sensor_node."""
+        return self._python_implementation
+
+    @property
+    def notice_info(self) -> NoticeInformation:
+        """Return the NoticeInformation for this sensor_node."""
+        if not self._notice_info:
+            self._notice_info = get_notice_info()
+        return self._notice_info
+
+    @property
+    def mqtt_client_id(self) -> str:
+        """Return the unique MQTT client ID for the sensor_node."""
+        return self._mqtt_client_id
 
     @property
     def cpu_temperature(self) -> float:
@@ -179,6 +228,20 @@ class Settings:
         if not self._stemma_bus:
             self._stemma_bus = board.STEMMA_I2C()
         return self._stemma_bus
+
+
+def get_notice_info() -> NoticeInformation:
+    """Return a serializable representation of the notice.toml file."""
+    notice_contents = []
+    with open("/snsr/notice.toml") as notice_toml:  # noqa: PTH123 -- Path.open() is not available on CircuitPython
+        notice_contents = notice_toml.read().splitlines()
+    notice_info = {}
+    for line in notice_contents:
+        key_and_value = line.split("=")
+        key = key_and_value[0].strip()
+        value = key_and_value[1].strip().replace('"', "")
+        notice_info[key] = value
+    return NoticeInformation.from_dict(notice_info)
 
 
 settings = Settings()

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -1,6 +1,7 @@
 """Global settings used by the sensor_node runtime."""
 
 import board
+import busio
 import digitalio
 
 
@@ -23,6 +24,7 @@ class Settings:
         self._initialize_from_env()
         self._initialize_dynamic_settings()
         self._dio_pins = {}
+        self._stemma_bus = None
         self._initialized = True
 
     def _initialize_from_env(self) -> None:
@@ -86,6 +88,12 @@ class Settings:
             return
         self._dio_pins[pin_name].deinit()
         del self._dio_pins[pin_name]
+
+    def get_stemma_i2c(self) -> busio.I2C:
+        """Initialize the Stemma as an I2C port."""
+        if not self._stemma_bus:
+            self._stemma_bus = board.STEMMA_I2C()
+        return self._stemma_bus
 
 
 settings = Settings()

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -1,5 +1,6 @@
 """Global settings used by the sensor_node runtime."""
 
+import analogio
 import board
 import busio
 import digitalio
@@ -23,7 +24,7 @@ class Settings:
             return
         self._initialize_from_env()
         self._initialize_dynamic_settings()
-        self._dio_pins = {}
+        self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn] = {}
         self._stemma_bus = None
         self._initialized = True
 
@@ -76,18 +77,30 @@ class Settings:
         """Set a new value for the node's boot time."""
         self._boot_time = new_boot_time
 
-    def get_dio_pin(self, pin_name: str) -> digitalio.DigitalInOut:
-        """Initialize the pin instance that matches the board's pin_name."""
-        if pin_name not in self._dio_pins:
-            self._dio_pins[pin_name] = digitalio.DigitalInOut(getattr(board, pin_name))
-        return self._dio_pins[pin_name]
+    def get_ai_pin(self, pin_name: str) -> analogio.AnalogIn:
+        """Initialize the analog input pin instance that matches the board's pin_name."""
+        if pin_name not in self._board_io_pins:
+            self._board_io_pins[pin_name] = analogio.AnalogIn(getattr(board, pin_name))
+        analog_input = self._board_io_pins[pin_name]
+        if not isinstance(analog_input, analogio.AnalogIn):
+            raise TypeError(type(analog_input), analogio.AnalogIn)
+        return analog_input
 
-    def release_dio_pin(self, pin_name: str) -> None:
+    def get_dio_pin(self, pin_name: str) -> digitalio.DigitalInOut:
+        """Initialize the digital io pin instance that matches the board's pin_name."""
+        if pin_name not in self._board_io_pins:
+            self._board_io_pins[pin_name] = digitalio.DigitalInOut(getattr(board, pin_name))
+        digital_io = self._board_io_pins[pin_name]
+        if not isinstance(digital_io, digitalio.DigitalInOut):
+            raise TypeError(type(digital_io), digitalio.DigitalInOut)
+        return digital_io
+
+    def release_pin(self, pin_name: str) -> None:
         """De-initialize the pin instance that matches the board's pin_name."""
-        if pin_name not in self._dio_pins:
+        if pin_name not in self._board_io_pins:
             return
-        self._dio_pins[pin_name].deinit()
-        del self._dio_pins[pin_name]
+        self._board_io_pins[pin_name].deinit()
+        del self._board_io_pins[pin_name]
 
     def get_stemma_i2c(self) -> busio.I2C:
         """Initialize the Stemma as an I2C port."""

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -244,4 +244,24 @@ def get_notice_info() -> NoticeInformation:
     return NoticeInformation.from_dict(notice_info)
 
 
+def format_wifi_information(wifi_radio: wifi.Radio) -> list[str]:
+    """Print details about the WiFi connection."""
+    if not wifi_radio.ap_info:
+        return []
+
+    lines = [
+        "Connected to WiFi",
+        "",
+        "     Network information",
+        f"Hostname: {wifi_radio.hostname}",
+        f"Tx Power: {wifi_radio.tx_power} dBm",
+        f"IP:       {wifi_radio.ipv4_address}",
+        f"DNS:      {wifi_radio.ipv4_dns}",
+        f"SSID:     {wifi_radio.ap_info.ssid}",
+        f"RSSI:     {wifi_radio.ap_info.rssi} dBm",
+        "",
+    ]
+    return lines
+
+
 settings = Settings()

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -4,6 +4,7 @@ import analogio
 import board
 import busio
 import digitalio
+import neopixel
 
 
 class Settings:
@@ -24,7 +25,7 @@ class Settings:
             return
         self._initialize_from_env()
         self._initialize_dynamic_settings()
-        self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn] = {}
+        self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
         self._stemma_bus = None
         self._initialized = True
 
@@ -76,6 +77,22 @@ class Settings:
     def boot_time(self, new_boot_time: float) -> None:
         """Set a new value for the node's boot time."""
         self._boot_time = new_boot_time
+
+    def get_neopixel(self) -> neopixel.NeoPixel:
+        """Return the NeoPixel on the board."""
+        pin_name = "NEOPIXEL"
+        if pin_name not in self._board_io_pins:
+            self._board_io_pins[pin_name] = neopixel.NeoPixel(
+                pin=getattr(board, pin_name), n=1, brightness=0.2, auto_write=False, pixel_order=neopixel.GRB
+            )
+        the_neopixel = self._board_io_pins[pin_name]
+        if not isinstance(the_neopixel, neopixel.NeoPixel):
+            raise TypeError(type(the_neopixel), neopixel.NeoPixel)
+        return the_neopixel
+
+    def release_neopixel(self) -> None:
+        """De-initialize the NeoPixel on the board."""
+        self.release_pin("NEOPIXEL")
 
     def get_ai_pin(self, pin_name: str) -> analogio.AnalogIn:
         """Initialize the analog input pin instance that matches the board's pin_name."""

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -67,6 +67,7 @@ class Settings:
         self._app_catalog = None  # Lazily loaded on first access
         self._wifi_radio = None
         self._board_io_pins: dict[str, digitalio.DigitalInOut | analogio.AnalogIn | neopixel.NeoPixel] = {}
+        self._settings_for_app_name: dict[str, dict] = {}
         self._stemma_bus = None
 
     @property
@@ -236,6 +237,16 @@ class Settings:
         if not self._stemma_bus:
             self._stemma_bus = board.STEMMA_I2C()
         return self._stemma_bus
+
+    def get_app_settings(self, app_name: str) -> dict:
+        """Get the settings for app_name."""
+        return self._settings_for_app_name.get(app_name, {})
+
+    def update_app_settings(self, app_name: str, settings: dict) -> None:
+        """Add or update the specified settings for app_name."""
+        app_settings = self._settings_for_app_name.get(app_name, {})
+        app_settings.update(settings)
+        self._settings_for_app_name.update({app_name: app_settings})
 
 
 def get_notice_info() -> NoticeInformation:

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -252,7 +252,7 @@ class Settings:
 def get_notice_info() -> NoticeInformation:
     """Return a serializable representation of the notice.toml file."""
     notice_contents = []
-    with open("/snsr/notice.toml") as notice_toml:  # noqa: PTH123 -- Path.open() is not available on CircuitPython
+    with open("/snsr/notice.toml") as notice_toml:
         notice_contents = notice_toml.read().splitlines()
     notice_info = {}
     for line in notice_contents:
@@ -268,12 +268,12 @@ def discover_apps() -> list[str]:
     from os import listdir, stat
 
     plain_file_stat = 0x8000
-    files = listdir("/snsr/apps")  # noqa: PTH208 -- pathlib not available on CircuitPython
+    files = listdir("/snsr/apps")
     apps = []
     for file in files:
         if file.startswith("__init__"):
             continue
-        if stat(f"/snsr/apps/{file}")[0] != plain_file_stat:  # noqa: PTH116 -- pathlib not available on CircuitPython
+        if stat(f"/snsr/apps/{file}")[0] != plain_file_stat:
             continue
         app_basename = file.split(".")[0]
         apps.append(app_basename)


### PR DESCRIPTION
## Summary

This PR adds **system details, IO pins, and sensor_node identifiers** to the `Settings` singleton.
- These traits are either constant or shared global resources.
- Conserve CPU cycles and energy by caching them rather than querying them for each access.

This PR adds **volatile system stats** to conserve import statements.

This PR adds **volatile settings for node-side apps**, which allows them to store their own context details.
- The settings preserve this context as long as the node does not enter deep sleep.
- The host-side app can simplify its protocol and messages when the node has stateful context and remains online. 
- The node-side app can keep resources like I2C or SPI devices initialized and configured without extra bus transactions.

Finally, this PR also **disables some `ruff` rules** for the sensor node files.

## Design

**settings.py**

- Add getters for immutable properties, usually used in MQTT responses
  - `board_id`
  - `serial_number`
  - `micropython_base`
  - `python_implementation`
  - `notice_info` _(lazily loaded on first access to help with import cycles)_
  - `mqtt_client_id`
  - `app_catalog` _(lazily loaded on first access to help with import cycles)_
- Add getters for volatile system stats
  - `cpu_temperature`
  - `used_kb`
  - `free_kb`
  - `uptime`
  - `uart_connected`
  - `uart_bytes_waiting`
- Add WiFi API
  - `connect_to_wifi()`
  - _(property)_ `wifi_radio`
  - _(propertt)_ `ip_address`
  - `disconnect_from_wifi()`
- Add NeoPixel API
  - `get_neopixel()`
  - `release_neopixel()`
- Add AnalogIn API
  - `get_ai_pin(pin_name)`
- Used shared dictionary for IO pins
-   - `release_pin(pin_name)`
- Add app settings API
  - `get_app_settings(app_name)`
  - `update_app_settings(app_name)`


**pyproject.toml**

Disable rules
- Some Python libraries are not available on CircuitPython
- Some design pattern deviations are expected
  - `INP001` -- No `__init__.py` because code.py is the entry point
  - `PLC0415` -- Allow non-toplevel imports to conserve memory
  - `PLR2004` -- Allow "magic number" literals to conserve memory
  - `PTH116` -- Path.stat() is not available
  - `PTH123` -- Path.open() is not available
  - `PTH208` -- Path.iterdir() is not available
  - `SIM105` -- contextlib is not available
  - `T201` -- Use direct IO for user REPL

## Screenshots or logs

**`qtpy-datalogger connect --group zone2`**
```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group 'zone2'
INFO     Identifying QT Py devices
INFO     QT Py device 'Adafruit QT Py ESP32-S3 no PSRAM' has UART and MQTT available, select a connection transport to continue
  1:  MQTT  (WiFi)
  2:  UART  (serial)
Enter a transport number (1, 2): 1
INFO     User-selected 'Adafruit QT Py ESP32-S3 no PSRAM' as MQTT node 'node-42cea4d12c8b-0' on '192.168.0.12'
Use any of 'exit' or 'quit' to exit.
node-42cea4d12c8b-0 > hello
Received 'received: hello' from node with 56.3125 kB used, 98.5625 kB remaining, at temperature 45.4 degC
node-42cea4d12c8b-0 > quit

INFO     Reconnect with 'qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0
```

## Testing

See log above.

## Checklist

- [x] Issues linked / labels applied
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
