### PR TITLE
Node: Use the Settings singleton

### DIFF
--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -4,49 +4,45 @@ from gc import collect
 from time import monotonic, sleep
 from traceback import print_exception
 
-from microcontroller import cpu
-from snsr.core import get_memory_info, paint_uart_line, read_one_uart_line
-from snsr.rxtx import connect_and_subscribe, connect_to_wifi, create_mqtt_client, unsubscribe_and_disconnect
+from snsr.core import paint_uart_line, read_one_uart_line
+from snsr.node.mqtt import get_broadcast_topic, get_command_topic
+from snsr.rxtx import connect_and_subscribe, create_mqtt_client, unsubscribe_and_disconnect
 from snsr.settings import settings
-from supervisor import runtime
 
 settings.boot_time = monotonic()
 print(f"Booted at {settings.boot_time:.3f}")
 
-node_identifier = f"node-{cpu.uid.hex().lower()}-0"  # Lower case matches boot_out.txt
 mqtt_topics = [
-    f"qtpy/v1/{settings.node_group}/broadcast",
-    f"qtpy/v1/{settings.node_group}/{node_identifier}/command",
+    get_broadcast_topic(settings.node_group),
+    get_command_topic(settings.node_group, settings.mqtt_client_id),
 ]
 
 
 def main_loop() -> str:
     """Run the main node loop."""
-    radio = connect_to_wifi()
-    mqtt_client = create_mqtt_client(radio, settings.node_group, node_identifier)
+    settings.connect_to_wifi()
+    mqtt_client = create_mqtt_client(settings.node_group, settings.mqtt_client_id)
     connect_and_subscribe(mqtt_client, mqtt_topics)
 
     response = ""
     while response.lower() not in ["exit", "quit"]:
-        if runtime.usb_connected and runtime.serial_connected:
-            uptime = monotonic() - settings.boot_time
-            paint_uart_line(f"  {uptime:>12.3f}    Poll UART     [ Poll MQTT ]     ")
+        uart_connected = settings.uart_connected
+        if uart_connected:
+            paint_uart_line(f"  {settings.uptime:>12.3f}    Poll UART     [ Poll MQTT ]     ")
         did_receive = mqtt_client.loop(timeout=1.0)  # Smallest supported timeout
-        if not (did_receive or runtime.serial_connected):
+        if not (did_receive or uart_connected):
             sleep(4)  # Conserve battery by not constantly polling the network
 
-        if runtime.usb_connected and runtime.serial_connected:
-            uptime = monotonic() - settings.boot_time
-            paint_uart_line(f"  {uptime:>12.3f}  [ Poll UART ]     Poll MQTT       ")
+        if uart_connected:
+            paint_uart_line(f"  {settings.uptime:>12.3f}  [ Poll UART ]     Poll MQTT       ")
             sleep(0.2)
-            if not runtime.serial_bytes_available:
+            if not settings.uart_bytes_waiting:
                 continue
             print()
             response = read_one_uart_line()
             if not response:
                 response = read_one_uart_line()
-            used_kb, free_kb = get_memory_info()
-            print(f"Received '{response}' with {used_kb} / {free_kb}  (used/free)")
+            print(f"Received '{response}' with {settings.used_kb:.3f} kB / {settings.free_kb:.3f} kB  (used/free)")
 
     unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
     return response

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
@@ -19,15 +19,6 @@ class SnsrApp:
         raise NotImplementedError()
 
 
-def get_catalog() -> list[str]:
-    """Return a list of the selectable apps."""
-    from os import listdir
-
-    files = listdir(str(__path__))
-    apps = [file.split(".")[0] for file in files if not file.startswith("__init__")]
-    return apps
-
-
 def get_app(received_action: ActionInformation) -> SnsrApp:
     """Return the sensor_node app that matches received_action."""
     snsr_app_name = received_action.command.split(" ")[0]

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -2,6 +2,7 @@
 
 from snsr.apps import SnsrApp
 from snsr.node.classes import ActionInformation
+from snsr.settings import settings
 
 
 class QtpyCmdApp(SnsrApp):
@@ -27,12 +28,11 @@ class QtpyCmdApp(SnsrApp):
 
 def handle_get_apps(received_action: ActionInformation) -> ActionInformation:
     """Handle the 'qtpycmd get_apps' action."""
-    from snsr.apps import get_catalog
-
+    apps = settings.app_catalog
     response_action = ActionInformation(
         command=received_action.parameters["input"],
         parameters={
-            "output": get_catalog(),
+            "output": sorted(apps),
             "complete": True,
         },
         message_id=received_action.message_id,

--- a/src/qtpy_datalogger/sensor_node/snsr/core.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/core.py
@@ -1,7 +1,5 @@
 """Core classes and functions."""
 
-from snsr.node.classes import DescriptorInformation, NoticeInformation
-
 
 def read_one_uart_line() -> str:
     """Read characters from the USB UART until a newline."""
@@ -36,51 +34,3 @@ def paint_uart_line(line: str) -> None:
         serial = usb_cdc.data
 
     redraw_line(line, out_stream=serial)  # type: ignore -- CircuitPython Serial objects have no parents
-
-
-def get_memory_info() -> tuple[str, str]:
-    """Return a tuple of formatted strings with used and free memory."""
-    import gc
-
-    used_bytes = gc.mem_alloc()
-    free_bytes = gc.mem_free()
-    return f"{used_bytes / 1024:.3f} kB", f"{free_bytes / 1024:.3f} kB"
-
-
-def get_notice_info() -> dict:
-    """Return a serializable representation of the notice.toml file."""
-    notice_contents = []
-    with open("/snsr/notice.toml") as notice_toml:
-        notice_contents = notice_toml.read().splitlines()
-    notice_info = {}
-    for line in notice_contents:
-        key_and_value = line.split("=")
-        key = key_and_value[0].strip()
-        value = key_and_value[1].strip().replace('"', "")
-        notice_info[key] = value
-    return notice_info
-
-
-def get_new_descriptor(  # noqa: PLR0913 -- allow more than 5 parameters for this function
-    role: str,
-    serial_number: str,
-    pid: int,
-    hardware_name: str,
-    micropython_base: str,
-    python_implementation: str,
-    ip_address: str,
-    notice: NoticeInformation,
-) -> DescriptorInformation:
-    """Return a DescriptorInformation instance using the specified parameters."""
-    from snsr.node.mqtt import format_mqtt_client_id
-
-    descriptor = DescriptorInformation(
-        node_id=format_mqtt_client_id(role, serial_number, pid),
-        serial_number=serial_number,
-        hardware_name=hardware_name,
-        system_name=f"python-{micropython_base}",
-        python_implementation=python_implementation,
-        ip_address=ip_address,
-        notice=notice,
-    )
-    return descriptor

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -3,13 +3,14 @@
 from json import dumps, loads
 
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
-from microcontroller import cpu
 
 from snsr import apps
 from snsr.node.classes import (
     ActionPayload,
     DescriptorInformation,
+    DescriptorPayload,
     SenderInformation,
+    StatusInformation,
 )
 from snsr.node.mqtt import get_descriptor_topic
 from snsr.settings import settings
@@ -40,12 +41,10 @@ def handle_broadcast_message(client: minimqtt.MQTT, action_payload: ActionPayloa
 
 def handle_identify(client: minimqtt.MQTT) -> None:
     """Respond to the the identify command."""
-    from wifi import radio
-
     context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
     descriptor_topic = get_descriptor_topic(context["node_group"], context["node_identifier"])
-    descriptor_message = get_descriptor_payload("node", cpu.uid.hex().lower(), str(radio.ipv4_address))
-    client.publish(descriptor_topic, descriptor_message)
+    descriptor_payload = get_descriptor_payload(descriptor_topic)
+    client.publish(descriptor_topic, dumps(descriptor_payload.as_dict()))
 
 
 def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload) -> None:
@@ -64,7 +63,7 @@ def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload)
     app = apps.get_app(action_information)
     result_information = app.handle_message()
 
-    sender = build_sender_information(descriptor_topic)
+    sender = get_sender_information(descriptor_topic)
     result_payload = ActionPayload(result_information, sender)
     client.publish(result_topic, dumps(result_payload.as_dict()))
     sleep(0.2)  # Allow the backend to send the message before invoking the completion which may sleep
@@ -72,62 +71,32 @@ def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload)
     app.did_handle_message()
 
 
-def get_descriptor_payload(role: str, serial_number: str, ip_address: str) -> str:
+def get_descriptor_payload(descriptor_topic: str) -> DescriptorPayload:
     """Return a serialized string representation of the DescriptorPayload."""
-    from snsr.node.classes import DescriptorPayload
-    from snsr.node.mqtt import format_mqtt_client_id
-
-    pid = 0
-    descriptor = build_descriptor_information(role, serial_number, ip_address)
-    client_id = format_mqtt_client_id(role, serial_number, pid)
-    descriptor_topic = get_descriptor_topic(settings.node_group, client_id)
-    sender = build_sender_information(descriptor_topic)
-    response = DescriptorPayload(descriptor=descriptor, sender=sender)
-    return dumps(response.as_dict())
-
-
-def build_descriptor_information(role: str, serial_number: str, ip_address: str) -> DescriptorInformation:
-    """Return a DescriptorInformation instance describing and identifying the client."""
-    from os import uname
-    from sys import implementation, version_info
-
-    from board import board_id
-
-    from snsr.core import get_new_descriptor, get_notice_info
-    from snsr.node.classes import NoticeInformation
-
-    pid = 0
-    system_info = uname()
-    micropython_base = ".".join([f"{version_number}" for version_number in version_info])
-    python_implementation = f"{implementation.name}-{system_info.release}"
-    notice_info = get_notice_info()
-    notice = NoticeInformation(**notice_info)
-
-    descriptor = get_new_descriptor(
-        role=role,
-        serial_number=serial_number,
-        pid=pid,
-        hardware_name=board_id,
-        micropython_base=micropython_base,
-        python_implementation=python_implementation,
-        ip_address=ip_address,
-        notice=notice,
+    descriptor = DescriptorInformation(
+        node_id=settings.mqtt_client_id,
+        serial_number=settings.serial_number,
+        hardware_name=settings.board_id,
+        system_name=f"python-{settings.micropython_base}",
+        python_implementation=settings.python_implementation,
+        ip_address=settings.ip_address,
+        notice=settings.notice_info,
     )
-    return descriptor
+    sender = get_sender_information(descriptor_topic)
+    payload = DescriptorPayload(descriptor=descriptor, sender=sender)
+    return payload
 
 
-def build_sender_information(descriptor_topic: str) -> SenderInformation:
+def get_sender_information(descriptor_topic: str) -> SenderInformation:
     """Return a SenderInformation instance describing the client's current state."""
     from time import monotonic
 
-    from snsr.node.classes import StatusInformation
-
     used_kb = settings.used_kb
     free_kb = settings.free_kb
-    cpu_celsius = cpu.temperature
-    monotonic_time = monotonic()
+    cpu_celsius = settings.cpu_temperature
+    now = monotonic()
     status = StatusInformation(
-        used_memory=str(used_kb), free_memory=str(free_kb), cpu_temperature=str(cpu_celsius)
+        used_memory=f"{used_kb:.3f}", free_memory=f"{free_kb:.3f}", cpu_temperature=str(cpu_celsius)
     )
-    sender = SenderInformation(descriptor_topic=descriptor_topic, sent_at=str(monotonic_time), status=status)
+    sender = SenderInformation(descriptor_topic=descriptor_topic, sent_at=str(now), status=status)
     return sender

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -24,7 +24,10 @@ def can_handle_message(message: str) -> None | ActionPayload:
         action_payload_information = loads(message)
     except ValueError:
         return None
-    action_payload = ActionPayload.from_dict(action_payload_information)
+    try:
+        action_payload = ActionPayload.from_dict(action_payload_information)
+    except (KeyError, TypeError):
+        return None
     return action_payload
 
 

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -12,7 +12,7 @@ from snsr.node.classes import (
     SenderInformation,
     StatusInformation,
 )
-from snsr.node.mqtt import get_descriptor_topic
+from snsr.node.mqtt import get_descriptor_topic, get_result_topic
 from snsr.settings import settings
 
 
@@ -41,8 +41,7 @@ def handle_broadcast_message(client: minimqtt.MQTT, action_payload: ActionPayloa
 
 def handle_identify(client: minimqtt.MQTT) -> None:
     """Respond to the the identify command."""
-    context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
-    descriptor_topic = get_descriptor_topic(context["node_group"], context["node_identifier"])
+    descriptor_topic = get_descriptor_topic(settings.node_group, settings.mqtt_client_id)
     descriptor_payload = get_descriptor_payload(descriptor_topic)
     client.publish(descriptor_topic, dumps(descriptor_payload.as_dict()))
 
@@ -51,13 +50,8 @@ def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload)
     """Respond to a message sent to the command topic for the node."""
     from time import sleep
 
-    from snsr.node.mqtt import get_result_topic
-
-    node_context: dict = client.user_data  # pyright: ignore reportAssignmentType -- the type for context is client-defined
-    node_group = node_context["node_group"]
-    node_identifier = node_context["node_identifier"]
-    result_topic = get_result_topic(node_group, node_identifier)
-    descriptor_topic = get_descriptor_topic(node_group, node_identifier)
+    result_topic = get_result_topic(settings.node_group, settings.mqtt_client_id)
+    descriptor_topic = get_descriptor_topic(settings.node_group, settings.mqtt_client_id)
     action_information = action_payload.action
 
     app = apps.get_app(action_information)

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -53,10 +53,6 @@ def create_mqtt_client(node_group: str, node_identifier: str) -> minimqtt.MQTT:
     mqtt_client = minimqtt.MQTT(
         broker=settings.mqtt_broker,
         socket_pool=pool,
-        user_data={
-            "node_group": node_group,
-            "node_identifier": node_identifier,
-        },
     )
 
     # Connect callback handlers to mqtt_client

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -1,7 +1,6 @@
 """Classes and functions for control and communication over MQTT."""
 
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
-import wifi
 
 from snsr.handlers import (
     can_handle_message,
@@ -9,37 +8,6 @@ from snsr.handlers import (
     handle_command_message,
 )
 from snsr.settings import settings
-
-
-def connect_to_wifi() -> wifi.Radio:
-    """Connect to the SSID from settings.toml and return the radio instance."""
-    settings.connect_to_wifi()
-    return wifi.radio
-
-
-def disconnect_from_wifi(wifi: wifi.Radio) -> None:
-    """Disconnect and disable the WiFi radio."""
-    settings.disconnect_from_wifi()
-
-
-def format_wifi_information(wifi: wifi.Radio) -> list[str]:
-    """Print details about the WiFi connection."""
-    if not wifi.ap_info:
-        return []
-
-    lines = [
-        "Connected to WiFi",
-        "",
-        "     Network information",
-        f"Hostname: {wifi.hostname}",
-        f"Tx Power: {wifi.tx_power} dBm",
-        f"IP:       {wifi.ipv4_address}",
-        f"DNS:      {wifi.ipv4_dns}",
-        f"SSID:     {wifi.ap_info.ssid}",
-        f"RSSI:     {wifi.ap_info.rssi} dBm",
-        "",
-    ]
-    return lines
 
 
 def on_connect(client: minimqtt.MQTT, userdata: object, flags: int, rc: int) -> None:
@@ -76,12 +44,12 @@ def on_message(client: minimqtt.MQTT, topic: str, message: str) -> None:
         handle_command_message(client, action_payload)
 
 
-def create_mqtt_client(radio: wifi.Radio, node_group: str, node_identifier: str) -> minimqtt.MQTT:
+def create_mqtt_client(node_group: str, node_identifier: str) -> minimqtt.MQTT:
     """Create an MQTT client and set its callback functions."""
     from adafruit_connection_manager import get_radio_socketpool
 
     # Set up a MiniMQTT Client
-    pool = get_radio_socketpool(radio)
+    pool = get_radio_socketpool(settings.wifi_radio)
     mqtt_client = minimqtt.MQTT(
         broker=settings.mqtt_broker,
         socket_pool=pool,

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -77,13 +77,3 @@ def unsubscribe_and_disconnect(mqtt_client: minimqtt.MQTT, topics: list[str]) ->
     for topic in topics:
         mqtt_client.unsubscribe(topic)
     mqtt_client.disconnect()
-
-
-def do_full_client_publish(mqtt_client: minimqtt.MQTT, message: str) -> None:
-    """Connect, publish, and disconnect."""
-    mqtt_topic = "qtpy/v1/__group_id__/__node_id__/__example__"
-    mqtt_client.connect()
-    mqtt_client.subscribe(mqtt_topic)
-    mqtt_client.publish(mqtt_topic, message)
-    mqtt_client.unsubscribe(mqtt_topic)
-    mqtt_client.disconnect()

--- a/tests/test_node_classes.py
+++ b/tests/test_node_classes.py
@@ -138,7 +138,7 @@ def test_host_build_descriptor() -> None:
     assert descriptor
 
 
-@pytest.mark.xfail(reason="The Settings singleton needs a fake or mock. See #XXX", strict=True)
+@pytest.mark.xfail(reason="The Settings singleton needs a fake or mock -- see #199", strict=True)
 def test_node_build_descriptor(monkeypatch: pytest.MonkeyPatch) -> None:
     """Does the node-side usage match the shared classes' definitions?"""
     # Support looking up sensor_node modules from the node's perspective (where 'snsr' is a package)

--- a/tests/test_node_classes.py
+++ b/tests/test_node_classes.py
@@ -138,29 +138,14 @@ def test_host_build_descriptor() -> None:
     assert descriptor
 
 
+@pytest.mark.xfail(reason="The Settings singleton needs a fake or mock. See #XXX", strict=True)
 def test_node_build_descriptor(monkeypatch: pytest.MonkeyPatch) -> None:
     """Does the node-side usage match the shared classes' definitions?"""
     # Support looking up sensor_node modules from the node's perspective (where 'snsr' is a package)
     sensor_node_root = pathlib.Path(__file__).parent.parent.joinpath("src", "qtpy_datalogger", "sensor_node")
     monkeypatch.syspath_prepend(sensor_node_root)
 
-    from qtpy_datalogger.datatypes import SnsrNotice
-    from qtpy_datalogger.sensor_node.snsr.core import get_new_descriptor as node_build_descriptor
+    from qtpy_datalogger.sensor_node.snsr.handlers import get_descriptor_payload as node_build_descriptor
 
-    snsr_notice = SnsrNotice.get_package_notice_info(allow_dev_version=True)
-    descriptor = node_build_descriptor(
-        role="node",
-        serial_number="ab12cd343ef56",
-        pid=0,
-        hardware_name="test_hardware_name",
-        micropython_base="3.4.0",
-        python_implementation="circuitpython-9.2.1",
-        ip_address="172.16.0.0",
-        notice=node_classes.NoticeInformation(
-            comment=snsr_notice.comment,
-            version=snsr_notice.version,
-            commit=snsr_notice.commit,
-            timestamp=snsr_notice.timestamp.isoformat(),
-        ),
-    )
-    assert descriptor
+    descriptor_payload = node_build_descriptor("descriptor/topic")
+    assert descriptor_payload


### PR DESCRIPTION
## Summary

This PR updates the files in the `sensor_node` bundle to use the Settings singleton object for their call sites.

This PR also adds error handling for the situation when the node receives JSON payloads via MQTT that are not an `ActionPayload`.

## Design

- Rather than using imports or custom functions
  - Use the properties from the Settings singleton or functions from the `node` submodules
  - Delete the unused code.
- `snsr.handlers`: Ignore JSON messages that do not match `ActionPayload` format
- `snsr.rxtx` / `snsr.handlers`: Remove MQTT client context
- `snsr.core` / `snsr.rxtx`: Delete unused code
- `test_node_classes`: Add `xfail` for the test that uses the Settings singleton

## Screenshots or logs

### Scanner app

<img width="640" height="626" alt="image" src="https://github.com/user-attachments/assets/80f2e025-26d4-4d62-873c-aa4ee31da8f6" />

### Console app

**`$ qtpy-datalogger connect --group zone2`**
```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group 'zone2'
INFO     Identifying QT Py devices
INFO     QT Py device 'Adafruit QT Py ESP32-S3 no PSRAM' has UART and MQTT available, select a connection transport to continue
  1:  MQTT  (WiFi)
  2:  UART  (serial)
Enter a transport number (1, 2): 1
INFO     User-selected 'Adafruit QT Py ESP32-S3 no PSRAM' as MQTT node 'node-42cea4d12c8b-0' on '192.168.0.12'
Use any of 'exit' or 'quit' to exit.
node-42cea4d12c8b-0 > hello
Received 'received: hello' from node with 83.766 kB used, 72.047 kB remaining, at temperature 46.4 degC
node-42cea4d12c8b-0 > qtpycmd get_apps
Received '['echo', 'qtpycmd']' from node with 94.344 kB used, 61.469 kB remaining, at temperature 46.4 degC
node-42cea4d12c8b-0 > quit

INFO     Reconnect with 'qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0'
```

## Testing

See above screenshots and logs.

## Checklist

- [x] Issues linked / labels applied
- [ ] Documentation updated
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
