### PR TITLE
Node: Add qtpycmd subcommands for stats, config, pixel, read

### DIFF
--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -59,6 +59,10 @@ while True:
             print("Exiting to REPL...")
             break
     except Exception as e:
+        try:
+            settings.disconnect_from_wifi()
+        except AttributeError:
+            pass
         print()
         print(f"Encountered {type(e)} {e.args}")
         print_exception(e)

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -15,6 +15,8 @@ class QtpyCmdApp(SnsrApp):
         verb = parts[1]
         if verb == "get_apps":
             return handle_get_apps(self.action, parts)
+        if verb == "stats":
+            return handle_get_stats(self.action, parts)
         if verb == "config":
             return handle_do_config(self.action, parts)
         if verb == "pixel":
@@ -54,6 +56,17 @@ def handle_get_apps(received_action: ActionInformation, command_args: list[str])
     """Handle the 'qtpycmd get_apps' action."""
     apps = settings.app_catalog
     return build_response(received_action, sorted(apps))
+
+
+def handle_get_stats(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+    """Handle the 'qtpycmd stats' action."""
+    import gc
+
+    gc.collect()
+    return build_response(
+        received_action,
+        f"{settings.used_kb:.3f} kB used | {settings.free_kb:.3f} kB free | {settings.uptime:.2f} s uptime",
+    )
 
 
 def handle_do_config(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -25,13 +25,13 @@ class QtpyCmdApp(SnsrApp):
             return handle_do_analog_read(self.action, parts)
 
         # Fallback to echo app
-        return use_echo(self.action, parts)
+        return use_echo(self.action)
 
     def did_handle_message(self) -> None:
         """Update the node after handling a message."""
 
 
-def use_echo(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+def use_echo(received_action: ActionInformation) -> ActionInformation:
     """Use echo to handle the action."""
     from snsr.apps.echo import EchoApp
 
@@ -71,18 +71,35 @@ def handle_get_stats(received_action: ActionInformation, command_args: list[str]
 
 def handle_do_config(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
     """Handle the 'qtpycmd config' action."""
-    return use_echo(received_action, command_args)
+    arg_count = len(command_args)
+    if arg_count <= 3:
+        return use_echo(received_action)
+
+    config_verb = command_args[2]
+    if config_verb not in ["get", "set"]:
+        return use_echo(received_action)
+
+    config_key = command_args[3]
+    if config_verb == "get":
+        config_setting = settings.get_app_settings("qtpycmd").get(config_key, "")
+        return build_response(received_action, message=f"{config_key}: {config_setting}")
+
+    if command_args == 5:
+        return use_echo(received_action)
+    config_setting = " ".join(command_args[4:])
+    settings.update_app_settings("qtpycmd", {config_key: config_setting})
+    return build_response(received_action, message=f"{config_key}: {config_setting}")
 
 
 def handle_do_pixel(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
     """Handle the 'qtpycmd pixel' action."""
     arg_count = len(command_args)
     if arg_count <= 2:
-        return use_echo(received_action, command_args)
+        return use_echo(received_action)
 
     pixel_verb = command_args[2]
     if pixel_verb != "blink":
-        return use_echo(received_action, command_args)
+        return use_echo(received_action)
 
     pixel_color = 0x2200AA
     if arg_count >= 4:
@@ -101,11 +118,11 @@ def handle_do_analog_read(received_action: ActionInformation, command_args: list
     """Handle the 'qtpycmd read' action."""
     arg_count = len(command_args)
     if arg_count <= 2:
-        return use_echo(received_action, command_args)
+        return use_echo(received_action)
 
     channels = [pin_name for pin_name in command_args[2:] if pin_name.startswith("A")]
     if not channels:
-        return use_echo(received_action, command_args)
+        return use_echo(received_action)
 
     from snsr.core import do_analog_scan
 

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -14,27 +14,88 @@ class QtpyCmdApp(SnsrApp):
         parts = system_command.split(" ")
         verb = parts[1]
         if verb == "get_apps":
-            return handle_get_apps(self.action)
+            return handle_get_apps(self.action, parts)
+        if verb == "config":
+            return handle_do_config(self.action, parts)
+        if verb == "pixel":
+            return handle_do_pixel(self.action, parts)
+        if verb == "read":
+            return handle_do_analog_read(self.action, parts)
 
         # Fallback to echo app
-        from snsr.apps.echo import EchoApp
-
-        echo = EchoApp(self.action)
-        return echo.handle_message()
+        return use_echo(self.action, parts)
 
     def did_handle_message(self) -> None:
         """Update the node after handling a message."""
 
 
-def handle_get_apps(received_action: ActionInformation) -> ActionInformation:
-    """Handle the 'qtpycmd get_apps' action."""
-    apps = settings.app_catalog
+def use_echo(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+    """Use echo to handle the action."""
+    from snsr.apps.echo import EchoApp
+
+    echo = EchoApp(received_action)
+    return echo.handle_message()
+
+
+def build_response(received_action: ActionInformation, message: object) -> ActionInformation:
+    """Create an action response with the specified message."""
     response_action = ActionInformation(
         command=received_action.parameters["input"],
         parameters={
-            "output": sorted(apps),
+            "output": message,
             "complete": True,
         },
         message_id=received_action.message_id,
     )
     return response_action
+
+
+def handle_get_apps(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+    """Handle the 'qtpycmd get_apps' action."""
+    apps = settings.app_catalog
+    return build_response(received_action, sorted(apps))
+
+
+def handle_do_config(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+    """Handle the 'qtpycmd config' action."""
+    return use_echo(received_action, command_args)
+
+
+def handle_do_pixel(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+    """Handle the 'qtpycmd pixel' action."""
+    arg_count = len(command_args)
+    if arg_count <= 2:
+        return use_echo(received_action, command_args)
+
+    pixel_verb = command_args[2]
+    if pixel_verb != "blink":
+        return use_echo(received_action, command_args)
+
+    pixel_color = 0x2200AA
+    if arg_count >= 4:
+        try:
+            pixel_color = int(command_args[3], 0)
+        except ValueError:
+            pass
+
+    from snsr.core import blink_neopixel
+
+    blink_neopixel(pixel_color)
+    return build_response(received_action, f"Used color 0x{pixel_color:06x}")
+
+
+def handle_do_analog_read(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
+    """Handle the 'qtpycmd read' action."""
+    arg_count = len(command_args)
+    if arg_count <= 2:
+        return use_echo(received_action, command_args)
+
+    channels = [pin_name for pin_name in command_args[2:] if pin_name.startswith("A")]
+    if not channels:
+        return use_echo(received_action, command_args)
+
+    from snsr.core import do_analog_scan
+
+    count = 15
+    voltages = do_analog_scan(channels, count)
+    return build_response(received_action, f"{voltages} (raw ADC codes, {count} samples averaged)")

--- a/src/qtpy_datalogger/sensor_node/snsr/core.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/core.py
@@ -1,4 +1,8 @@
-"""Core classes and functions."""
+"""Core functions for the sensor_node runtime."""
+
+import analogio
+
+from snsr.settings import settings
 
 
 def read_one_uart_line() -> str:
@@ -34,3 +38,39 @@ def paint_uart_line(line: str) -> None:
         serial = usb_cdc.data
 
     redraw_line(line, out_stream=serial)  # type: ignore -- CircuitPython Serial objects have no parents
+
+
+def blink_neopixel(color: int) -> None:
+    """Blink the NeoPixel three times with the specified RGB color."""
+    from time import sleep
+
+    pixel = settings.get_neopixel()
+    for _ in range(3):
+        pixel.fill(color)
+        pixel.show()
+        sleep(0.2)
+        pixel.fill(0)
+        pixel.show()
+        sleep(0.2)
+    settings.release_neopixel()
+
+
+def do_analog_scan(channels: list[str], count: int) -> list[float]:
+    """Read the specified AI channels 'count' times each and return a list of averaged codes."""
+    results = []
+    analog_input_channels = [settings.get_ai_pin(pin_name) for pin_name in channels]
+    for analog_input in analog_input_channels:
+        average_channel_code = adc_take_n(analog_input, count)
+        results.append(average_channel_code)
+    for pin_name in channels:
+        settings.release_pin(pin_name)
+    return results
+
+
+def adc_take_n(ai_pin: analogio.AnalogIn, count: int) -> float:
+    """Read ai_pin 'count' times and return the average code."""
+    total = 0.0
+    for _ in range(count):
+        total = total + ai_pin.value
+    average = total / count
+    return average


### PR DESCRIPTION
## Summary

This PR adds subcommands to the `qtpycmd` app on the `sensor_node`.
- `stats`
  - Get a string of current status like _"56.453 kB used | 99.359 kB free | 28.25 s uptime"_
- `config [get|set] key [value]`
  - Set and get values by name
  - `qtpycmd config set key1 value can be multiword` creates or updates the value for `key1`
  - `qtpycmd config get key1` returns a message like _"key1: value can be multiword"_
- `pixel blink [color]`
  - Blink the NeoPixel three times, where `color` is an RGB numeric value
  - `qtpycmd pixel blink 0xff0000` blinks red
- `read`
  - Read from IO pins
  - `qtpycmd read A0 A1 A2 A3` returns a message like _"[287.6, 15222.6, 8056.9, 22347.2] (raw ADC codes, 15 samples averaged)"_

This PR also improves main loop error handling by disconnecting from WiFi when the loop exits with an error.

## Design

- Add functions to `snsr.core` to support the `qtpycmd` subcommands
  - `blink_neopixel(color)` -- Blink the NeoPixel three times with the specified RGB `color`.
  - `do_analog_scan(channels, count)` -- Read the specified AI `channels` `count` times each and return a list of averaged codes.
  - `adc_take_n(ai_pin, count)` -- Read `ai_pin` `count` times and return the average code.
- Add functions to `snsr.apps.qtpycmd` to handle the new subcommands

## Screenshots or logs

**`$ qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0`**
```
Use any of 'exit' or 'quit' to exit.
node-42cea4d12c8b-0 > hello
Received 'received: hello' from node with 54.703 kB used, 101.109 kB remaining, at temperature 47.4 degC
node-42cea4d12c8b-0 > qtpycmd stats
Received '56.453 kB used | 99.359 kB free | 28.25 s uptime' from node with 56.656 kB used, 99.156 kB remaining, at temperature 47.4 degC
node-42cea4d12c8b-0 > qtpycmd config get key1
Received 'key1: ' from node with 79.359 kB used, 76.453 kB remaining, at temperature 46.4 degC
node-42cea4d12c8b-0 > qtpycmd config set key1 value can be multiword
Received 'key1: value can be multiword' from node with 117.938 kB used, 37.875 kB remaining, at temperature 47.4 degC
node-42cea4d12c8b-0 > qtpycmd config get key1
Received 'key1: value can be multiword' from node with 59.266 kB used, 96.547 kB remaining, at temperature 46.4 degC
node-42cea4d12c8b-0 > qtpycmd stats
Received '56.578 kB used | 99.234 kB free | 80.23 s uptime' from node with 56.781 kB used, 99.031 kB remaining, at temperature 47.4 degC
node-42cea4d12c8b-0 > qtpycmd read A0 A1 A2 A3
Received '[2.6, 0.0, 0.0, 0.0] (raw ADC codes, 15 samples averaged)' from node with 82.047 kB used, 73.766 kB remaining, at temperature 47.4 degC
node-42cea4d12c8b-0 > qtpycmd pixel blink
Received 'Used color 0x2200aa' from node with 96.828 kB used, 58.984 kB remaining, at temperature 44.4 degC
node-42cea4d12c8b-0 > qtpycmd pixel blink red
Received 'Used color 0x2200aa' from node with 107.969 kB used, 47.844 kB remaining, at temperature 44.4 degC
node-42cea4d12c8b-0 > qtpycmd pixel blink 0xff0000
Received 'Used color 0xff0000' from node with 124.656 kB used, 31.156 kB remaining, at temperature 44.4 degC
node-42cea4d12c8b-0 > qtpycmd stats
Received '56.609 kB used | 99.203 kB free | 125.39 s uptime' from node with 56.813 kB used, 99.000 kB remaining, at temperature 45.4 degC
node-42cea4d12c8b-0 > quit

INFO     Reconnect with 'qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0'
```

## Testing

See logs above.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
