### PR TITLE
Node API: Use factory pattern for running apps

### DIFF
--- a/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/__init__.py
@@ -19,15 +19,9 @@ class SnsrApp:
         raise NotImplementedError()
 
 
-def get_app(received_action: ActionInformation) -> SnsrApp:
-    """Return the sensor_node app that matches received_action."""
-    snsr_app_name = received_action.command.split(" ")[0]
-    if snsr_app_name == "custom" and received_action.parameters["input"].startswith("qtpycmd "):
-        from snsr.apps.qtpycmd import QtpyCmdApp
+def use_echo(received_action: ActionInformation) -> ActionInformation:
+    """Use echo to handle the action."""
+    from snsr.apps.echo import create_app
 
-        return QtpyCmdApp(received_action)
-
-    # Fallback to echo app handler
-    from snsr.apps.echo import EchoApp
-
-    return EchoApp(received_action)
+    echo_app = create_app(received_action)
+    return echo_app.handle_message()

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
@@ -22,3 +22,8 @@ class EchoApp(SnsrApp):
 
     def did_handle_message(self) -> None:
         """Update the node after handling a message."""
+
+
+def create_app(received_action: ActionInformation) -> SnsrApp:
+    """Return a new EchoApp."""
+    return EchoApp(received_action)

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -1,6 +1,6 @@
 """App that queries and demonstrates board resources like IO pins."""
 
-from snsr.apps import SnsrApp
+from snsr.apps import SnsrApp, use_echo
 from snsr.node.classes import ActionInformation
 from snsr.settings import settings
 
@@ -31,12 +31,9 @@ class QtpyCmdApp(SnsrApp):
         """Update the node after handling a message."""
 
 
-def use_echo(received_action: ActionInformation) -> ActionInformation:
-    """Use echo to handle the action."""
-    from snsr.apps.echo import EchoApp
-
-    echo = EchoApp(received_action)
-    return echo.handle_message()
+def create_app(received_action: ActionInformation) -> SnsrApp:
+    """Return a new QtpyCmdApp."""
+    return QtpyCmdApp(received_action)
 
 
 def build_response(received_action: ActionInformation, message: object) -> ActionInformation:

--- a/src/qtpy_datalogger/sensor_node/snsr/core.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/core.py
@@ -2,6 +2,8 @@
 
 import analogio
 
+from snsr.apps import SnsrApp
+from snsr.node.classes import ActionInformation
 from snsr.settings import settings
 
 
@@ -38,6 +40,19 @@ def paint_uart_line(line: str) -> None:
         serial = usb_cdc.data
 
     redraw_line(line, out_stream=serial)  # type: ignore -- CircuitPython Serial objects have no parents
+
+
+def get_app(received_action: ActionInformation) -> SnsrApp:
+    """Return the sensor_node app that matches received_action."""
+    snsr_app_name = received_action.command.split(" ")[0]
+    if snsr_app_name == "custom" and received_action.parameters["input"].startswith("qtpycmd "):
+        snsr_app_name = "qtpycmd"
+    if snsr_app_name not in settings.app_catalog:
+        snsr_app_name = "echo"
+
+    snsr_app_module = __import__(f"snsr/apps/{snsr_app_name}")
+    app = snsr_app_module.create_app(received_action)
+    return app
 
 
 def blink_neopixel(color: int) -> None:

--- a/src/qtpy_datalogger/sensor_node/snsr/handlers.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/handlers.py
@@ -4,7 +4,7 @@ from json import dumps, loads
 
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 
-from snsr import apps
+from snsr.core import get_app
 from snsr.node.classes import (
     ActionPayload,
     DescriptorInformation,
@@ -57,7 +57,7 @@ def handle_command_message(client: minimqtt.MQTT, action_payload: ActionPayload)
     descriptor_topic = get_descriptor_topic(settings.node_group, settings.mqtt_client_id)
     action_information = action_payload.action
 
-    app = apps.get_app(action_information)
+    app = get_app(action_information)
     result_information = app.handle_message()
 
     sender = get_sender_information(descriptor_topic)

--- a/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/rxtx.py
@@ -1,4 +1,4 @@
-"""Classes and functions for control and communication over MQTT."""
+"""Functions for communication over MQTT."""
 
 import adafruit_minimqtt.adafruit_minimqtt as minimqtt
 


### PR DESCRIPTION
## Summary

This PR changes how the `sensor_node` runtime loads and runs apps. Before this PR, the runtime used hardcoded import statements to conserve RAM. Now we add another API requirement for apps: implement a top-level factory function named `create_app()`.

## Design

- Move `get_app()` from `snsr.apps` to `snsr.core`
- Change implementation from hardcoded import statements to dynamic import by name

### Discussion

Using the app's constructor to create the app requires either
- Hardcoded import statements to import the app's class
  - Does not allow "drag and drop" installation for casual or preview apps
- Module introspection to find the app's subclass of `SnsrApp`
  - Uses ~10kB RAM from initial exploration

Using a top-level factory function allows the runtime to always import the same `create_app` symbol name.
- No hardcoded import statements for each app
- No module introspection searching for subclasses

## Screenshots or logs

<img width="638" height="649" alt="image" src="https://github.com/user-attachments/assets/81e43ed4-8f74-4902-9d25-2fd7fc4e785c" />

## Testing

- See above screenshot

## Checklist

- [x] Issues linked / labels applied
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
