### PR TITLE
equip CLI: Add 'collections' to PC-only filter so node import summaries do not show the module

### DIFF
--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 _PC_ONLY_IMPORTS = [
     "typing",
+    "collections",
 ]
 
 _EQUIP_IGNORE_PATTERNS = frozenset(


### PR DESCRIPTION
## Summary

This PR removes confusing output from the `equip` subcommand.

## Design

The code in `sensor_node` imports `collections` for type hints, but this module is not available on CircuitPython. Without filtering out these PC-only imports, the `equip` output misrepresents was runtime modules the node actually uses.

## Screenshots or logs

- The `collections` module is no longer printed during `equip`.

```diff
  INFO     Found 20 total module references   * external   . builtin   ~ internal
  INFO      * adafruit_connection_manager
  INFO      * adafruit_minimqtt
  INFO      * neopixel
  INFO      . analogio
  INFO      . board
  INFO      . busio
- INFO      . collections
  INFO      . digitalio
  INFO      . gc
  INFO      . json
  INFO      . microcontroller
  INFO      . os
  INFO      . supervisor
  INFO      . sys
  INFO      . time
  INFO      . usb_cdc
  INFO      . wifi
  INFO      ~ linebuffer
  INFO      ~ py_shell
  INFO      ~ snsr
```

## Testing

See log above.

## Checklist

- [x] Issues linked / labels applied
- [x] Documentation updated
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
