### PR TITLE
Scanner app: Use guikit.create_combo_box() for node selector

### DIFF
--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -182,12 +182,13 @@ class ScannerApp(guikit.AsyncWindow):
         self.status_icon_label.pack(side=tk.LEFT)
         self.status_message = ttk.Label(selection_status_frame, borderwidth=0, relief=tk.SOLID)
         self.status_message.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=(8, 0))
-        self.selected_node_combobox = ttk.Combobox(
+        self.selected_node_combobox = guikit.create_dropdown_combobox(
             selection_status_frame,
+            values=[Constants.NoneChoice],
             width=20,
-            state=bootstyle.READONLY,
+            justify=bootstyle.RIGHT,
+            completion=self.on_combobox_selected,
         )
-        self.selected_node_combobox.bind("<<ComboboxSelected>>", self.on_combobox_selected)
         self.selected_node_combobox.pack(side=tk.LEFT, padx=(8, 0))
 
         message_frame = ttk.Frame(comms_frame, name="message_frame")
@@ -262,15 +263,12 @@ class ScannerApp(guikit.AsyncWindow):
 
         self.on_node_selected(selected_serial_number)
 
-    def on_combobox_selected(self, event_args: tk.Event) -> None:
+    def on_combobox_selected(self, new_selection: str) -> None:
         """Handle the user selecting a new entry in the combobox."""
-        if not isinstance(event_args.widget, ttk.Combobox):
-            raise TypeError()
-        selected_value = event_args.widget.get()
         selected_serial_number = Constants.NoneChoice
         for _, devices_in_group in self.scan_db.devices_by_group.items():
             for serial_number, device_info in devices_in_group.items():
-                if selected_value in [device_info.node_id, device_info.com_port]:
+                if new_selection in [device_info.node_id, device_info.com_port]:
                     selected_serial_number = serial_number
         self.on_node_selected(selected_serial_number)
 

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -11,7 +11,7 @@ import tkinter as tk
 import webbrowser
 from collections.abc import Callable
 from tkinter import font
-from typing import ClassVar, Literal, NamedTuple
+from typing import ClassVar, NamedTuple
 
 import click
 import ttkbootstrap as ttk
@@ -742,24 +742,9 @@ def create_theme_combobox(parent: tk.BaseWidget) -> ttk.Combobox:
             raise ValueError()
     sorted_by_kind = [*sorted(light_themes), *sorted(dark_themes)]
 
-    theme_combobox = ttk.Combobox(
-        parent,
-        width=12,
-        values=sorted_by_kind,
-    )
-    theme_combobox.set(active_theme.name.capitalize())
-    theme_combobox.configure(state=bootstyle.READONLY)
-    theme_combobox.selection_clear()
-
-    def handle_change_theme(event_args: tk.Event) -> None:
+    def handle_change_theme(new_selection: str) -> None:
         """Handle the selection event for the theme Combobox."""
-        sending_combobox = event_args.widget
-        if not isinstance(sending_combobox, ttk.Combobox):
-            raise TypeError()
-        theme_name = sending_combobox.get().lower()
-        sending_combobox.configure(state=bootstyle.READONLY)
-        sending_combobox.selection_clear()
-        ThemeChanger.use_bootstrap_theme(theme_name, sending_combobox)
+        ThemeChanger.use_bootstrap_theme(new_selection.lower(), parent)
 
     def on_theme_changed(themed_widget: tk.Misc, event_args: tk.Event) -> None:
         """Handle the ThemeChanger.Event.BootstrapThemeChanged event."""
@@ -771,7 +756,14 @@ def create_theme_combobox(parent: tk.BaseWidget) -> ttk.Combobox:
             raise ValueError()
         sending_combobox.set(style.theme.name.capitalize())
 
-    theme_combobox.bind("<<ComboboxSelected>>", handle_change_theme)
+    theme_combobox = create_dropdown_combobox(
+        parent,
+        values=sorted_by_kind,
+        width=12,
+        justify=bootstyle.LEFT,
+        completion=handle_change_theme,
+    )
+    theme_combobox.set(active_theme.name.capitalize())
     ThemeChanger.add_handler(theme_combobox, functools.partial(on_theme_changed, theme_combobox))
     return theme_combobox
 

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -804,7 +804,7 @@ def create_dropdown_combobox(
     parent: tk.Misc,
     values: list[str],
     width: int,
-    justify: Literal["left", "center", "right"],
+    justify: bootstyle.Side,
     completion: Callable[[str], None],
 ) -> ttk.Combobox:
     """Create a ttk.Combobox that only allows selection of entries."""


### PR DESCRIPTION
## Summary

This PR changes how apps in the package create select-only comboboxes so that they all use the function `create_combo_box()` from the `guikit` submodule.

## Design

- `create_combo_box()`: Use `bootstyle.Side` to match the library's type hint
- `guikit` demo app: Use `create_combo_box()` for the theme changer combobox
- `scanner` app: Use `guikit.create_combo_box()` for node selector

## Screenshots or logs

### guikit demo app

<img width="711" height="283" alt="combobox-guikit-demo gif" src="https://github.com/user-attachments/assets/1946d5f2-e9d2-4cff-a90d-44d24a009c22" />

### Scanner app

<img width="643" height="611" alt="combobox-scanner-demo gif" src="https://github.com/user-attachments/assets/97a4ab69-c4a8-45b1-93f6-a4a907ea1dc7" />

## Testing

See above screenshots.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
