### PR TITLE
Workflows: Add publish.yml preview

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,162 @@
+name: 'Publish: Release on PyPI'
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag_override:
+        # Use this input for previewing or debugging the workflow
+        # Publishing to PyPI still requires a GitHub release event to start this workflow
+        description: 'Override the release tag: M.m.u'
+        required: true
+        type: string
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    name: Build distribution packages
+    runs-on: windows-latest
+    steps:
+    - name: Get source code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Install poetry
+      run: |
+        echo '# :checkered_flag: Release on PyPI _(run ${{ github.run_number }} attempt ${{ github.run_attempt }})_' >> $env:GITHUB_STEP_SUMMARY
+        pipx install poetry
+        poetry about
+        poetry config --list
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.11'
+        cache: poetry
+
+    - name: Install dependencies
+      run: |
+        poetry self add 'poethepoet[poetry_plugin]'
+        poetry install
+        echo '## :package: Installed plugins and dependencies' >> $env:GITHUB_STEP_SUMMARY
+        echo '```' >> $env:GITHUB_STEP_SUMMARY
+        poetry self show plugins >> $env:GITHUB_STEP_SUMMARY
+        poetry show >> $env:GITHUB_STEP_SUMMARY
+        echo '```' >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Confirm release coherence
+      run: |
+        import json
+        import packaging.version
+        import subprocess
+
+        tag_name = "${{ inputs.release_tag_override }}" or "${{ github.event.release.tag_name }}"
+        error_messages = []
+        print(f"Checking release tag name {tag_name}")
+
+        # Confirm the release tag version matches the package version
+        tag_version = packaging.version.Version(tag_name)
+        str_version = subprocess.check_output(["poetry", "version", "--short"]).strip().decode()
+        pkg_version = packaging.version.Version(str_version)
+        if tag_version != pkg_version:
+            error_messages.append(f"Version mismatch: tag is {tag_version} and package is {pkg_version}")
+
+        # Confirm the releasing version hasn't been published already
+        released_text = subprocess.check_output(["curl", "-s", "https://pypi.org/pypi/qtpy-datalogger/json"]).strip().decode()
+        released_json = json.loads(released_text)
+        released_dicts = released_json.get("releases", {})
+        released_versions = sorted([packaging.version.Version(key) for key in released_dicts], reverse=True)
+        if pkg_version in released_versions:
+            error_messages.append(f"Version collision: version {pkg_version} is already published")
+
+        if error_messages:
+            exit_message = "\n".join(error_messages)
+            raise ValueError(exit_message)
+      shell: poetry run python {0}
+
+    - name: Build package
+      run: poetry build --verbose
+
+    - name: Upload release packages
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: release-distribution-packages
+        path: dist/
+
+  publish:
+    name: Publish to PyPI
+    if: github.event_name == 'release'
+    runs-on: windows-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qtpy-datalogger
+    permissions:
+      id-token: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: release-distribution-packages
+        path: dist/
+    - run: ls -lR
+    # - name: Upload to PyPI
+    #   uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+  update_version:
+    name: Update version
+    runs-on: windows-latest
+    # needs: publish
+    needs: build
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - name: Get source code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Install poetry
+      run: |
+        echo '# :sparkle: Update package version' >> $env:GITHUB_STEP_SUMMARY
+        pipx install poetry
+        poetry about
+        poetry config --list
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.11'
+        cache: poetry
+
+    - name: Install dependencies
+      run: |
+        poetry self add 'poethepoet[poetry_plugin]'
+        poetry install
+        echo '## :package: Installed plugins and dependencies' >> $env:GITHUB_STEP_SUMMARY
+        echo '```' >> $env:GITHUB_STEP_SUMMARY
+        poetry self show plugins >> $env:GITHUB_STEP_SUMMARY
+        poetry show >> $env:GITHUB_STEP_SUMMARY
+        echo '```' >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Update package version
+      id: update_version
+      run: |
+        new_version=$(poetry version patch --short)
+        echo "new_version=$new_version" >> $GITHUB_OUTPUT
+        echo "## New version: `$new_version`" >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Create pull request
+      id: create_pr
+      uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+      with:
+        branch: 'users/build/update-package-version-to-${{ steps.update_version.outputs.new_version }}'
+        commit-message: 'Automated update version to ${{ steps.update_version.outputs.new_version }}'
+        title: 'Package: Update version to ${{ steps.update_version.outputs.new_version }}'
+        body:  |
+          This PR updates the version to ${{ steps.update_version.outputs.new_version }}.
+
+          See ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/publish.yml for details.
+
+    - name: Write summary
+      run: |
+        echo '## Pull request' >> $GITHUB_STEP_SUMMARY
+        echo "- ${{ steps.create_pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR adds a `publish.yml` workflow file to enable publishing releases to PyPI.

## Design

- On-demand input: tag name override
- Job 1: Build after confirming release coherence
  - Fail if the release tag and `pyproject.toml` disagree about the the version
  - Fail if the release has already been published to PyPI
- Job 2: Publish to PyPI on GitHub release events
- Job 3: Update the package version and open a PR

## Screenshots or logs

Testing can begin once the workflow is in `main`.

## Testing

Testing can begin once the workflow is in `main`.

## Checklist

- [ ] Issues linked / labels applied
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
