### PR TITLE
publish.yml: Fix shell-exec-escape, tidy summary markdown

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install poetry
       run: |
-        echo '# :checkered_flag: Release on PyPI _(run ${{ github.run_number }} attempt ${{ github.run_attempt }})_' >> $env:GITHUB_STEP_SUMMARY
+        echo '# :flying_saucer: Release on PyPI _(run ${{ github.run_number }} attempt ${{ github.run_attempt }})_' >> $env:GITHUB_STEP_SUMMARY
         pipx install poetry
         poetry about
         poetry config --list
@@ -131,18 +131,13 @@ jobs:
       run: |
         poetry self add 'poethepoet[poetry_plugin]'
         poetry install
-        echo '## :package: Installed plugins and dependencies' >> $env:GITHUB_STEP_SUMMARY
-        echo '```' >> $env:GITHUB_STEP_SUMMARY
-        poetry self show plugins >> $env:GITHUB_STEP_SUMMARY
-        poetry show >> $env:GITHUB_STEP_SUMMARY
-        echo '```' >> $env:GITHUB_STEP_SUMMARY
 
     - name: Update package version
       id: update_version
       run: |
         new_version=$(poetry version patch --short)
         echo "new_version=$new_version" >> $GITHUB_OUTPUT
-        echo "## New version: `$new_version`" >> $env:GITHUB_STEP_SUMMARY
+        echo "## New version: $new_version" >> $env:GITHUB_STEP_SUMMARY
 
     - name: Create pull request
       id: create_pr


### PR DESCRIPTION
## Summary

This shell code confuses the interpreter because the backtick characters also mean subshell substitution.

```sh
 echo "## New version: `$new_version`" >> $env:GITHUB_STEP_SUMMARY
```

## Design

Simplify the markdown.

## Screenshots or logs

Testing happens after the updates are in `main`.

## Testing

Testing happens after the updates are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
