### PR TITLE
publish.yml: Fix pwsh syntax for capturing command output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         echo '# :flying_saucer: Release on PyPI _(run ${{ github.run_number }} attempt ${{ github.run_attempt }})_' >> $env:GITHUB_STEP_SUMMARY
         pipx install poetry
+        pipx environment --value PIPX_HOME
         poetry about
         poetry config --list
 
@@ -105,7 +106,6 @@ jobs:
   update_version:
     name: Update version
     runs-on: windows-latest
-    # needs: publish
     needs: build
     permissions:
       contents: write
@@ -135,7 +135,7 @@ jobs:
     - name: Update package version
       id: update_version
       run: |
-        new_version=$(poetry version patch --short)
+        $new_version = $(poetry version patch --short)
         echo "new_version=$new_version" >> $GITHUB_OUTPUT
         echo "## New version: $new_version" >> $env:GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary

This PR fixes `pwsh` syntax for capturing command output.

## Design

- Add debug info about a pipx warning in the logs
- Don't reserve 'publish' as a prerequisite for updating the package version.
  - It's possible that PyPI is unavailable but the GitHub release has already completed.

## Screenshots or logs

Testing happens after the updates are in `main`.

## Testing

Testing happens after the updates are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
