### PR TITLE
publish.yml: Fix pwsh syntax for list-recursively, narrow to the dist folder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
     - run: |
         echo '# :snake: Upload to PyPI' >> $env:GITHUB_STEP_SUMMARY
         echo '- [Release history](https://pypi.org/project/qtpy-datalogger/#history)' >> $env:GITHUB_STEP_SUMMARY
-        ls -lR
+        ls -Recurse -Force dist
 
   update_version:
     name: Update version


### PR DESCRIPTION
## Summary

This PR fixes a runtime error in the `publish.yml` workflow that happens after releases.

## Design

- Fix the `pwsh` syntax for listing a folder's contents and narrow it to the build artifacts folder.

## Screenshots or logs

Testing happens after the changes are in `main`.

## Testing

Testing happens after the changes are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
