### PR TITLE
publish.yml: Specify and select the base for the PR's branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,6 +151,7 @@ jobs:
       id: create_pr
       uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
       with:
+        base: "${{ github.event_name == 'release' && github.event.release.target_commitish || github.ref_name }}"
         branch: 'users/build/update-package-version-to-${{ steps.update_version.outputs.new_version }}'
         commit-message: 'Automated version update to ${{ steps.update_version.outputs.new_version }}'
         title: 'pyproject.toml: Update version to ${{ steps.update_version.outputs.new_version }}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qtpy-datalogger"
-version = "0.2.0"
+version = "0.2.1"
 description = "Data acquisition application using Adafruit QT Py S3"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"


### PR DESCRIPTION
## Summary

This PR fixes the `publish.yml` workflow for release events.
- Fix the `pwsh` syntax for listing a folder's contents
- Specify and select the base for the PR's branch

We also update the package version to `0.2.1` to exercise the workflow again.

## Design

For release events, `github.ref_name` is the release tag (e.g. 1.0.0) and `github.event.release.target_commitish` is the branch/tag/commit that the tag was created from (e.g. `main`).

For `workflow_dispatch` events, `github.ref_name` is the branch/tag/commit that the workflow was dispatched on.

## Screenshots or logs

Testing happens after the changes are in `main`.

## Testing

Testing happens after the changes are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
