### PR TITLE
ci.yml: Add Python 3.12 and 3.13 to matrix strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python_version: ['3.11']
+        python_version: [
+          '3.11',
+          '3.12',
+          '3.13',
+          '3.14',
+        ]
 
     steps:
     - name: Get source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     name: Test on Python ${{ matrix.python_version }}
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: [
           '3.11',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,17 @@ jobs:
         poetry show >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
 
-    - name: Run pytest
+    - name: ':test_tube: Run pytest'
       run: poetry run pytest --verbose --junit-xml=junit/pytest-results-${{ runner.os }}-${{ matrix.python_version }}.xml
 
-    - name: Run ruff check
+    - name: ':mag: Run ruff check'
       id: ruff-check
       run: |
         poetry run ruff check --output-format github
         poetry run ruff check --output-format junit --output-file junit/ruff-check-results-${{ runner.os }}-${{ matrix.python_version }}.xml
       if: always()
 
-    - name: Run ruff format --diff
+    - name: ':mag: Run ruff format --diff'
       run: |
         poetry run ruff format --diff
         echo '## :microscope: ruff check errors' >> $env:GITHUB_STEP_SUMMARY
@@ -86,7 +86,7 @@ jobs:
       if: ${{ failure() && steps.ruff-check.conclusion == 'failure' }}
       continue-on-error: true
 
-    - name: Run pyright
+    - name: ':mag: Run pyright'
       run: |
         poetry run pyright --dependencies
         echo '## :microscope: pyright results' >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,17 +53,17 @@ jobs:
         poetry show >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
 
-    - name: ':test_tube: Run pytest'
+    - name: Run pytest
       run: poetry run pytest --verbose --junit-xml=junit/pytest-results-${{ runner.os }}-${{ matrix.python_version }}.xml
 
-    - name: ':mag: Run ruff check'
+    - name: Run ruff check
       id: ruff-check
       run: |
         poetry run ruff check --output-format github
         poetry run ruff check --output-format junit --output-file junit/ruff-check-results-${{ runner.os }}-${{ matrix.python_version }}.xml
       if: always()
 
-    - name: ':mag: Run ruff format --diff'
+    - name: Run ruff format --diff
       run: |
         poetry run ruff format --diff
         echo '## :microscope: ruff check errors' >> $env:GITHUB_STEP_SUMMARY
@@ -87,7 +87,7 @@ jobs:
       if: ${{ failure() && steps.ruff-check.conclusion == 'failure' }}
       continue-on-error: true
 
-    - name: ':mag: Run pyright'
+    - name: Run pyright
       run: |
         poetry run pyright --dependencies
         echo '## :microscope: pyright results' >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           '3.11',
           '3.12',
           '3.13',
-          '3.14',
+          # '3.14',   In some way, tkfontawesome brings lxml 5.4 which is not available for Python 3.14
         ]
 
     steps:


### PR DESCRIPTION
## Summary

Security support for [Python 3.11 ends in 2027](https://devguide.python.org/versions/#status-of-python-versions), and this change adds a version of Python that increases support for this package into 2029.

## Design

This PR adds more Python versions to the CI matrix to validate that this package is compatible with these newer versions of Python.
- Update the list of Python versions
  - The dependency `ttkfontawesome` uses `lxml` 5.4 which is not available for Python 3.14

## Screenshots or logs

- These changes are tested in this PR's checks

## Testing

- These changes are tested in this PR's checks

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
