### PR TITLE
Communication API: Add UART support for ActionPayload messages

### DIFF
--- a/src/qtpy_datalogger/discovery.py
+++ b/src/qtpy_datalogger/discovery.py
@@ -270,7 +270,6 @@ def open_session_on_port(port: str) -> None:
     logger.info(f"---   Quit: {quit_command}        Help: {help_command} then H   ---")
 
     miniterm.start()
-    com_port.write(b"\r\n")
     with contextlib.suppress(KeyboardInterrupt):
         miniterm.join(True)
     miniterm.join()

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -10,8 +10,6 @@ from snsr.rxtx import connect_and_subscribe, create_mqtt_client, unsubscribe_and
 from snsr.settings import settings
 
 settings.boot_time = monotonic()
-print(f"Booted at {settings.boot_time:.3f}")
-
 mqtt_topics = [
     get_broadcast_topic(settings.node_group),
     get_command_topic(settings.node_group, settings.mqtt_client_id),
@@ -27,18 +25,14 @@ def main_loop() -> str:
     response = ""
     while response.lower() not in ["exit", "quit"]:
         uart_connected = settings.uart_connected
-        if uart_connected:
-            paint_uart_line(f"  {settings.uptime:>12.3f}    Poll UART     [ Poll MQTT ]     ")
         did_receive = mqtt_client.loop(timeout=1.0)  # Smallest supported timeout
         if not (did_receive or uart_connected):
             sleep(4)  # Conserve battery by not constantly polling the network
 
         if uart_connected:
-            paint_uart_line(f"  {settings.uptime:>12.3f}  [ Poll UART ]     Poll MQTT       ")
             sleep(0.2)
             if not settings.uart_bytes_waiting:
                 continue
-            print()
             response = read_one_uart_line()
             if not response:
                 response = read_one_uart_line()
@@ -52,7 +46,6 @@ most_recent_error = type(None)
 error_count = 0
 error_limit = 3
 while True:
-    print("Entering root loop")
     try:
         result = main_loop()
         if result.lower() in ["exit", "quit"]:

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -6,9 +6,9 @@ from time import monotonic, sleep
 from traceback import print_exception
 
 from snsr.core import get_app, read_one_uart_line
-from snsr.handlers import can_handle_message
-from snsr.node.classes import create_custom_with_input
-from snsr.node.mqtt import get_broadcast_topic, get_command_topic
+from snsr.handlers import can_handle_message, get_sender_information
+from snsr.node.classes import ActionPayload, create_custom_with_input
+from snsr.node.mqtt import get_broadcast_topic, get_command_topic, get_descriptor_topic
 from snsr.rxtx import connect_and_subscribe, create_mqtt_client, unsubscribe_and_disconnect
 from snsr.settings import settings
 
@@ -42,10 +42,20 @@ def main_loop() -> str:
             if not action_payload:
                 action_payload = create_custom_with_input(uart_input.strip())
                 made_custom = True
+
             app = get_app(action_payload.action)
             result = app.handle_message()
-            response = result.parameters["output"] if made_custom else dumps(result.as_dict())
+
+            response = ""
+            if made_custom:
+                response = result.parameters["output"]
+            else:
+                descriptor_topic = get_descriptor_topic(settings.node_group, settings.mqtt_client_id)
+                sender_information = get_sender_information(descriptor_topic)
+                result_payload = ActionPayload(result, sender_information)
+                response = dumps(result_payload.as_dict())
             print(response)
+
             app.did_handle_message()
 
     unsubscribe_and_disconnect(mqtt_client, mqtt_topics)

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -7,6 +7,7 @@ from traceback import print_exception
 
 from snsr.core import get_app, read_one_uart_line
 from snsr.handlers import can_handle_message
+from snsr.node.classes import create_custom_with_input
 from snsr.node.mqtt import get_broadcast_topic, get_command_topic
 from snsr.rxtx import connect_and_subscribe, create_mqtt_client, unsubscribe_and_disconnect
 from snsr.settings import settings
@@ -37,13 +38,15 @@ def main_loop() -> str:
                 continue
             uart_input = read_one_uart_line(message="")
             action_payload = can_handle_message(uart_input)
-            if action_payload:
-                app = get_app(action_payload.action)
-                result = app.handle_message()
-                print(dumps(result.as_dict()))
-                app.did_handle_message()
-            else:
-                print(f"Received '{uart_input}' with {settings.used_kb:.3f} kB / {settings.free_kb:.3f} kB  (used/free)")
+            made_custom = False
+            if not action_payload:
+                action_payload = create_custom_with_input(uart_input.strip())
+                made_custom = True
+            app = get_app(action_payload.action)
+            result = app.handle_message()
+            response = result.parameters["output"] if made_custom else dumps(result.as_dict())
+            print(response)
+            app.did_handle_message()
 
     unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
     return uart_input

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -1,10 +1,12 @@
 """code.py file is the main loop from qtpy_datalogger.sensor_node."""
 
 from gc import collect
+from json import dumps
 from time import monotonic, sleep
 from traceback import print_exception
 
-from snsr.core import paint_uart_line, read_one_uart_line
+from snsr.core import get_app, read_one_uart_line
+from snsr.handlers import can_handle_message
 from snsr.node.mqtt import get_broadcast_topic, get_command_topic
 from snsr.rxtx import connect_and_subscribe, create_mqtt_client, unsubscribe_and_disconnect
 from snsr.settings import settings
@@ -22,8 +24,8 @@ def main_loop() -> str:
     mqtt_client = create_mqtt_client(settings.node_group, settings.mqtt_client_id)
     connect_and_subscribe(mqtt_client, mqtt_topics)
 
-    response = ""
-    while response.lower() not in ["exit", "quit"]:
+    uart_input = ""
+    while uart_input.lower() not in ["exit", "quit"]:
         uart_connected = settings.uart_connected
         did_receive = mqtt_client.loop(timeout=1.0)  # Smallest supported timeout
         if not (did_receive or uart_connected):
@@ -33,13 +35,18 @@ def main_loop() -> str:
             sleep(0.2)
             if not settings.uart_bytes_waiting:
                 continue
-            response = read_one_uart_line()
-            if not response:
-                response = read_one_uart_line()
-            print(f"Received '{response}' with {settings.used_kb:.3f} kB / {settings.free_kb:.3f} kB  (used/free)")
+            uart_input = read_one_uart_line(message="")
+            action_payload = can_handle_message(uart_input)
+            if action_payload:
+                app = get_app(action_payload.action)
+                result = app.handle_message()
+                print(dumps(result.as_dict()))
+                app.did_handle_message()
+            else:
+                print(f"Received '{uart_input}' with {settings.used_kb:.3f} kB / {settings.free_kb:.3f} kB  (used/free)")
 
     unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
-    return response
+    return uart_input
 
 
 most_recent_error = type(None)

--- a/src/qtpy_datalogger/sensor_node/snsr/core.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/core.py
@@ -7,7 +7,7 @@ from snsr.node.classes import ActionInformation
 from snsr.settings import settings
 
 
-def read_one_uart_line() -> str:
+def read_one_uart_line(message: str = "[uart] ") -> str:
     """Read characters from the USB UART until a newline."""
     import usb_cdc
 
@@ -22,7 +22,7 @@ def read_one_uart_line() -> str:
     if not serial:
         return ""
 
-    line = prompt(message="[uart] ", in_stream=serial, out_stream=serial)  # type: ignore -- CircuitPython Serial objects have no parents
+    line = prompt(message=message, in_stream=serial, out_stream=serial)  # type: ignore -- CircuitPython Serial objects have no parents
     _ = serial.read(serial.in_waiting)
     return line
 

--- a/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
@@ -330,3 +330,26 @@ class ActionPayload:
     def sender(self) -> SenderInformation:
         """The sender of the payload."""
         return SenderInformation.from_dict(self.information["sender"])
+
+
+def create_custom_with_input(input_string: str) -> ActionPayload:
+    """Return an ActionPayload for a custom command with the specified input."""
+    payload = ActionPayload(
+        action=ActionInformation(
+            command="custom",
+            parameters={
+                "input": input_string,
+            },
+            message_id="create_custom_with_input",
+        ),
+        sender=SenderInformation(
+            descriptor_topic="unused",
+            sent_at="unused",
+            status=StatusInformation(
+                used_memory="unused",
+                free_memory="unused",
+                cpu_temperature="unused",
+            ),
+        ),
+    )
+    return payload


### PR DESCRIPTION
## Summary

This PR adds support for a `sensor_node` to receive and respond to serial input with `ActionPayload` messages.

The node now responds to `ActionPayload` messages in the same way over both MQTT and UART.

## Design

**`code.py`**
- Rework the serial input and output to remove unnecessary print statements
- Treat the input string as an `ActionPayload`
- Fall back to wrapping the input string in a **custom** `ActionPayload`
  - Removes the need to type the surrounding JSON structure with input from a keyboard

**`discovery.py`**
- Stop breaking into the node's main loop with a newline message on connection

## Screenshots or logs

### UART

**`$ qtpy-datalogger connect --port COM18`**
```
INFO     ---   Miniterm on COM18   Opts: 115200,8,N,1    ---
INFO     ---   Quit: Ctrl+]        Help: Ctrl+T then H   ---
hello
received: hello
qtpycmd get_apps
['echo', 'qtpycmd']
qtpycmd stats
59.328 kB used | 78.797 kB free | 2303.68 s uptime
{"action": {"command": "custom", "parameters": {"input": "qtpycmd stats"}, "message_id": "github-demo"}, "sender": {"descriptor_topic": "unused", "sent_at": "unused", "status": {"used_memory": "unused", "free_memory": "unused", "cpu_temperature": "unused"}}}
{"sender": {"sent_at": "11912.1", "status": {"free_memory": "78.422", "cpu_temperature": "42.4", "used_memory": "59.203"}, "descriptor_topic": "qtpy/v1/zone2/node-42cea4d12c8b-0/$DESCRIPTOR"}, "action": {"parameters": {"output": "58.859 kB used | 78.766 kB free | 21.66 s uptime", "complete": true}, "message_id": "github-demo", "command": "qtpycmd stats"}}

INFO     Reconnect with 'qtpy-datalogger connect --port COM18'
```

### MQTT

**`$ qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0`**
```
Use any of 'exit' or 'quit' to exit.
node-42cea4d12c8b-0 > hello
Received 'received: hello' from node with 67.406 kB used, 70.719 kB remaining, at temperature 41.4 degC
node-42cea4d12c8b-0 > qtpycmd get_apps
Received '['echo', 'qtpycmd']' from node with 73.188 kB used, 64.938 kB remaining, at temperature 42.4 degC
node-42cea4d12c8b-0 > qtpycmd stats
Received '61.094 kB used | 77.031 kB free | 2347.54 s uptime' from node with 61.297 kB used, 76.828 kB remaining, at temperature 41.4 degC
node-42cea4d12c8b-0 > exit

INFO     Reconnect with 'qtpy-datalogger connect --group zone2 --node node-42cea4d12c8b-0'
```

## Testing

See logs above.

## Checklist

- [x] Issues linked / labels applied
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
