### PR TITLE
publish.yml: Change to ubuntu runner for the publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
   publish:
     name: Publish to PyPI
     if: github.event_name == 'release'
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: build
     environment:
       name: pypi
@@ -108,10 +108,10 @@ jobs:
     - name: 'Upload to PyPI'
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
     - run: |
-        echo '# :snake: Upload to PyPI' >> $env:GITHUB_STEP_SUMMARY
-        echo '## Version ${{ github.event.release.tag_name }} published' >> $env:GITHUB_STEP_SUMMARY
-        echo '## Release history' >> $env:GITHUB_STEP_SUMMARY
-        echo '- https://pypi.org/project/qtpy-datalogger/#history' >> $env:GITHUB_STEP_SUMMARY
+        echo '# :snake: Upload to PyPI' >> $GITHUB_STEP_SUMMARY
+        echo '## Version ${{ github.event.release.tag_name }} published' >> $GITHUB_STEP_SUMMARY
+        echo '## Release history' >> $GITHUB_STEP_SUMMARY
+        echo '- https://pypi.org/project/qtpy-datalogger/#history' >> $GITHUB_STEP_SUMMARY
         ls -Recurse -Force dist
 
   update_version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qtpy-datalogger"
-version = "1.0.0"
+version = "1.0.1"
 description = "Data acquisition application using Adafruit QT Py S3"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"


### PR DESCRIPTION
## Summary

The PyPA action for trusted publishing requires a Linux environment.

This PR changes the environment of the publishing to `ubuntu-latest`.

## Design

- Change the `runs-on` to `ubuntu-latest`
- Change the append-to-summary syntax

## Screenshots or logs

We test these changes in the publish workflow.

## Testing

We test these changes in the publish workflow.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
