### PR TITLE
publish.yml: Use bash syntax for listing the dist folder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
         echo '## Version ${{ github.event.release.tag_name }} published' >> $GITHUB_STEP_SUMMARY
         echo '## Release history' >> $GITHUB_STEP_SUMMARY
         echo '- https://pypi.org/project/qtpy-datalogger/#history' >> $GITHUB_STEP_SUMMARY
-        ls -Recurse -Force dist
+        ls -lR dist
 
   update_version:
     name: Update version


### PR DESCRIPTION
## Summary

This PR fixes the publish step's syntax for listing the contents of the uploaded assets.

## Design

Use `bash` syntax for `ls`.

## Screenshots or logs

We cannot test with a preview even after these changes are in `main`.

## Testing

We cannot test with a preview even after these changes are in `main`.

The whole job is skipped unless it's associated with a release.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
