### PR TITLE
README: Add link to Structure section for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Dependabot Updates]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates)
 [![Publish: Release on PyPI](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/publish.yml/badge.svg)](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/publish.yml)
 
-## Structure
+## [Structure](https://github.com/wireddown/qt-py-s3-daq-app#structure)
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary

This PR add a link to the **Structure** section in the GitHub hosted README so PyPI readers can click to see the illustration.

## Design

- Add an absolute URL link

## Screenshots or logs

- See the README

## Testing

- PR checks

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
