### PR TITLE
Docs: Use 'upload-pages-artifact' to upload for publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,10 +45,9 @@ jobs:
     - name: Build documentation
       run: poetry run zensical build --clean
 
-    - name: Upload site
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    - name: Upload site artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
-        name: documentation-site
         path: site/
 
   publish:


### PR DESCRIPTION
## Summary

This PR updates the `docs.yml` workflow to correctly publish documentation.

The [`deploy-pages` action](https://github.com/actions/deploy-pages) requires the [`upload-pages-artifact` action](https://github.com/actions/upload-pages-artifact) for uploading the artifacts.

## Design

- Update the step to use the action

## Screenshots or logs

We can test this once the changes are in `main`.

## Testing

We can test this once the changes are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
