### PR TITLE
Docs: Do not use 'download-artifact' for 'deploy-pages'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,11 +62,6 @@ jobs:
         pages: write
         id-token: write
     steps:
-    - name: Download build artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: documentation-site
-        path: site/
     - name: Deploy doc site
       id: deployment
       uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary

This PR fixes the publish job in the `docs.yml` workflow.

## Design

Do not use 'download-artifact' for 'deploy-pages' because the preceding job does not use 'upload-artifact'.

## Screenshots or logs

We test actions that are not triggered by PRs once the changes are in `main`.

## Testing

We test actions that are not triggered by PRs once the changes are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
