### PR TITLE
Repo: Rename qt-py-s3-daq-app to qtpy-datalogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# QT Py S3 DAQ App
+# QT Py Datalogger
 
 **`qtpy-datalogger`** -- A data acquisition application using the [Adafruit QT Py S3] and [CircuitPython].
 
 ## Status
 
-[![CI: Tests and Analyzers](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml/badge.svg)](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/ci.yml)
-[![Dependabot Updates]](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates)
-[![Publish: Release on PyPI](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/publish.yml/badge.svg)](https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/publish.yml)
+[![CI: Tests and Analyzers](https://github.com/wireddown/qtpy-datalogger/actions/workflows/ci.yml/badge.svg)](https://github.com/wireddown/qtpy-datalogger/actions/workflows/ci.yml)
+[![Dependabot Updates]](https://github.com/wireddown/qtpy-datalogger/actions/workflows/dependabot/dependabot-updates)
+[![Publish: Release on PyPI](https://github.com/wireddown/qtpy-datalogger/actions/workflows/publish.yml/badge.svg)](https://github.com/wireddown/qtpy-datalogger/actions/workflows/publish.yml)
 
-## [Structure](https://github.com/wireddown/qt-py-s3-daq-app#structure)
+## [Structure](https://github.com/wireddown/qtpy-datalogger#structure)
 
 ```mermaid
 graph LR
@@ -47,8 +47,8 @@ graph LR
 - Network / MQTT
 
 **Entry points**
-- Host program: [`qtpy_datalogger/console.py`](https://github.com/wireddown/qt-py-s3-daq-app/blob/main/src/qtpy_datalogger/console.py)
-- QT Py program: [`qtpy_datalogger/sensor_node/code.py`](https://github.com/wireddown/qt-py-s3-daq-app/blob/main/src/qtpy_datalogger/sensor_node/code.py)
+- Host program: [`qtpy_datalogger/console.py`](https://github.com/wireddown/qtpy-datalogger/blob/main/src/qtpy_datalogger/console.py)
+- QT Py program: [`qtpy_datalogger/sensor_node/code.py`](https://github.com/wireddown/qtpy-datalogger/blob/main/src/qtpy_datalogger/sensor_node/code.py)
 
 ## Preview in 90 seconds
 
@@ -99,7 +99,7 @@ qtpy-datalogger run scanner
 Scan for nodes by group.
 Select a node to send it messages.
 
-![Screenshot of the scanner app](https://raw.githubusercontent.com/wireddown/qt-py-s3-daq-app/refs/heads/main/docs/gallery/app-scanner.png)
+![Screenshot of the scanner app](https://raw.githubusercontent.com/wireddown/qtpy-datalogger/refs/heads/main/docs/gallery/app-scanner.png)
 
 ### Data Viewer
 
@@ -109,7 +109,7 @@ qtpy-datalogger run data-viewer
 
 Open a CSV file for time series data.
 
-![Screenshot of the data viewer app](https://raw.githubusercontent.com/wireddown/qt-py-s3-daq-app/refs/heads/main/docs/gallery/app-data-viewer.png)
+![Screenshot of the data viewer app](https://raw.githubusercontent.com/wireddown/qtpy-datalogger/refs/heads/main/docs/gallery/app-data-viewer.png)
 
 CSV format
 - Series data are in columns
@@ -143,14 +143,14 @@ This project replaces a legacy system that uses Python and JeeNodes.
 See the [summary and source code] in the `docs/legacy` folder for details.
 
 
-[Dependabot Updates]: https://github.com/wireddown/qt-py-s3-daq-app/actions/workflows/dependabot/dependabot-updates/badge.svg
+[Dependabot Updates]: https://github.com/wireddown/qtpy-datalogger/actions/workflows/dependabot/dependabot-updates/badge.svg
 
 [Adafruit QT Py S3]: https://learn.adafruit.com/adafruit-qt-py-esp32-s3
 [CircuitPython]: https://circuitpython.org/
 
-[MQTT setup and commissioning]: https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT
+[MQTT setup and commissioning]: https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-5-MQTT
 
-[wiki home page]: https://github.com/wireddown/qt-py-s3-daq-app/wiki
-[Contributing]: https://github.com/wireddown/qt-py-s3-daq-app/wiki/Contributing
-[Design Doc]: https://github.com/wireddown/qt-py-s3-daq-app/wiki/Design-Doc-1-Overview
-[summary and source code]: https://github.com/wireddown/qt-py-s3-daq-app/blob/main/docs/legacy/README.md
+[wiki home page]: https://github.com/wireddown/qtpy-datalogger/wiki
+[Contributing]: https://github.com/wireddown/qtpy-datalogger/wiki/Contributing
+[Design Doc]: https://github.com/wireddown/qtpy-datalogger/wiki/Design-Doc-1-Overview
+[summary and source code]: https://github.com/wireddown/qtpy-datalogger/blob/main/docs/legacy/README.md

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://github.com/wireddown/qt-py-s3-daq-app/issues/new/choose.
+https://github.com/wireddown/qtpy-datalogger/issues/new/choose.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 _(maintained in  the wiki)_
 
-[Contributing]: https://github.com/wireddown/qt-py-s3-daq-app/wiki/Contributing
+[Contributing]: https://github.com/wireddown/qtpy-datalogger/wiki/Contributing

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,4 +8,4 @@ This software disclaims any guarantees against security vulnerabilities.
 
 If you encounter a vulnerability, create a [new GitHub Issue].
 
-[new GitHub issue]: https://github.com/wireddown/qt-py-s3-daq-app/issues/new/choose
+[new GitHub issue]: https://github.com/wireddown/qtpy-datalogger/issues/new/choose

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -2,4 +2,4 @@
 
 This project uses [GitHub Issues] to track bugs and feature requests.
 
-[GitHub Issues]: https://github.com/wireddown/qt-py-s3-daq-app/issues/new/choose
+[GitHub Issues]: https://github.com/wireddown/qtpy-datalogger/issues/new/choose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
 dynamic = ["dependencies"]
 
 [project.urls]
-homepage = "https://github.com/wireddown/qt-py-s3-daq-app"
-source = "https://github.com/wireddown/qt-py-s3-daq-app"
-changelog = "https://github.com/wireddown/qt-py-s3-daq-app/releases"
-documentation = "https://github.com/wireddown/qt-py-s3-daq-app/wiki"
-issues = "https://github.com/wireddown/qt-py-s3-daq-app/issues"
+homepage = "https://github.com/wireddown/qtpy-datalogger"
+source = "https://github.com/wireddown/qtpy-datalogger"
+changelog = "https://github.com/wireddown/qtpy-datalogger/releases"
+documentation = "https://github.com/wireddown/qtpy-datalogger/wiki"
+issues = "https://github.com/wireddown/qtpy-datalogger/issues"
 
 [project.scripts]
 qtpy-datalogger = "qtpy_datalogger.__main__:main"

--- a/src/qtpy_datalogger/datatypes.py
+++ b/src/qtpy_datalogger/datatypes.py
@@ -19,11 +19,11 @@ import toml
 class Links(enum.StrEnum):
     """URLs for references and help."""
 
-    Source = "https://github.com/wireddown/qt-py-s3-daq-app"
-    Homepage = "https://github.com/wireddown/qt-py-s3-daq-app/wiki"
-    New_Bug = "https://github.com/wireddown/qt-py-s3-daq-app/issues/new?template=bug-report.md"
+    Source = "https://github.com/wireddown/qtpy-datalogger"
+    Homepage = "https://github.com/wireddown/qtpy-datalogger/wiki"
+    New_Bug = "https://github.com/wireddown/qtpy-datalogger/issues/new?template=bug-report.md"
     Board_Support_Matrix = "https://docs.circuitpython.org/en/stable/shared-bindings/support_matrix.html"
-    MQTT_Walkthrough = "https://github.com/wireddown/qt-py-s3-daq-app/wiki/Walkthrough-5-MQTT"
+    MQTT_Walkthrough = "https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-5-MQTT"
 
 
 class ExitCode(enum.IntEnum):

--- a/src/qtpy_datalogger/sensor_node/qtpy_sensor_node.md
+++ b/src/qtpy_datalogger/sensor_node/qtpy_sensor_node.md
@@ -4,9 +4,9 @@ The `snsr` folder and its subfolders are an overlay for a CircuitPython device.
 The code adds functions to perform data logging from analog channels and I2C devices.
 
 - Homepage
-  - https://github.com/wireddown/qt-py-s3-daq-app/wiki
+  - https://github.com/wireddown/qtpy-datalogger/wiki
 - Source code
-  - https://github.com/wireddown/qt-py-s3-daq-app/tree/main/src/qtpy_datalogger/sensor_node
+  - https://github.com/wireddown/qtpy-datalogger/tree/main/src/qtpy_datalogger/sensor_node
 
 ## Quick start
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -11,7 +11,7 @@
 # The site_name is shown in the page header and the browser window title
 #
 # Read more: https://zensical.org/docs/setup/basics/#site_name
-site_name = "QT Py S3 DAQ App"
+site_name = "QT Py Datalogger"
 
 # The site_description is included in the HTML head and should contain a
 # meaningful description of the site content for use by search engines.
@@ -29,7 +29,7 @@ site_author = "Joe Friedrichsen"
 # documentation you should set this.
 # Read more: https://zensical.org/docs/setup/basics/#site_url
 #site_url = "https://www.example.com/"
-repo_url = "https://github.com/wireddown/qt-py-s3-daq-app"
+repo_url = "https://github.com/wireddown/qtpy-datalogger"
 
 # The copyright notice appears in the page footer and can contain an HTML
 # fragment.


### PR DESCRIPTION
## Summary

This PR propagates the repo's name change from `qt-py-s3-daq-app` to match it's command line name `qtpy-datalogger`.

## Design

Update repo references and titles.

## Screenshots or logs

See the previews in the PR.

## Testing

Normal PR checks.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
