### PR TITLE
Docs: Add page trees for Help and onboarding Guides

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -13,7 +13,7 @@ This is a crash course introducing the tools and libraries used in the project.
 
 ??? question "New to git and Python?"
 
-    If these tools and commands are not on your system, go to the section [First time setup](#first-time-setup) at the bottom.
+    If these tools and commands are not on your system, follow the introductory [Guide pages](/eng/intro/tools).
 
 ### Requirements
 
@@ -234,13 +234,3 @@ Design documents for this project are in the wiki under the [**Design Doc X**](h
 ## Pull requests and Issues
 
 See the sections under the [Project Workflows](https://github.com/wireddown/qtpy-datalogger/wiki/Project-Workflows) wiki page for outlines.
-
-## First time setup
-
-If the tools and commands referenced above are not on your system, follow the instructions in these walkthroughs to install and configure them.
-
-1. [Tools](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-1-Tools)
-1. [Git](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-2-Git)
-1. [Python](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-3-Python)
-1. [QT Py](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-4-QT-Py)
-1. [MQTT](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-5-MQTT)

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -114,7 +114,10 @@ uv run qtpy-datalogger [OPTIONS]
 
 ### PC dev loop
 
-!!! info "Use `qtpy-datalogger server --observe` to monitor the messages sent between nodes and the host"
+??? info "Monitor the messages sent between nodes and the host"
+    ```pwsh
+    uv run qtpy-datalogger server --observe
+    ```
 
 ```pwsh
 # ✍️ Save source code changes
@@ -134,9 +137,15 @@ uv run poe fix
 
 ### QT Py dev loop
 
-!!! info "Use `qtpy-datalogger server --observe` to monitor the messages sent between nodes and the host"
+??? info "Monitor the messages sent between nodes and the host"
+    ```pwsh
+    uv run qtpy-datalogger server --observe
+    ```
 
-!!! info "Use `qtpy-datalogger connect --port COMxx` to monitor the main run loop on the QT Py node"
+??? info "Monitor the main run loop on the QT Py node"
+    ```pwsh
+    uv run qtpy-datalogger connect --port COMxx
+    ```
 
 !!! tip ":lucide-cable:{ .lg .middle }&nbsp; Connect the QT Py device to your workstation with USB"
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -71,6 +71,9 @@ uv sync
 # Confirm dependencies are satisfied
 uv sync --check
 
+# Confirm GUI component readiness
+uv run qtpy-datalogger run data-viewer
+
 # Confirm MQTT server readiness
 uv run qtpy-datalogger server
 
@@ -80,8 +83,8 @@ uv run qtpy-datalogger connect --discover-only
 # Confirm node readiness
 uv run qtpy-datalogger equip --compare
 
-# Install or upgrade node runtime
-uv run qtpy-datalogger equip
+# Send a message to the QT Py over WiFi
+uv run qtpy-datalogger run scanner
 ```
 
 ## Workflows

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -17,9 +17,9 @@ This is a crash course introducing the tools and libraries used in the project.
 
 ### Requirements
 
-- :fontawesome-brands-git-alt:&nbsp; `git`
-- :fontawesome-brands-python:&nbsp; Python and `uv`
-- :fontawesome-solid-wifi:&nbsp; MQTT broker
+- :fontawesome-brands-git-alt:{ .lg .middle }&nbsp; `git`
+- :fontawesome-brands-python:{ .lg .middle }&nbsp; Python and `uv`
+- :fontawesome-solid-wifi:{ .lg }&nbsp; MQTT broker
 
 ### Do once
 
@@ -49,7 +49,7 @@ Once installed, [configure](https://github.com/wireddown/qtpy-datalogger/wiki/Wa
 
 **4. Initialize QT Py device**
 
-!!! tip ":lucide-cable:&nbsp; Connect the QT Py device to your workstation with USB"
+!!! tip ":lucide-cable:{ .lg .middle }&nbsp; Connect the QT Py device to your workstation with USB"
 
 ```pwsh
 # Install and configure the sensor node runtime
@@ -58,7 +58,7 @@ uv run qtpy-datalogger equip --secrets -
 
 ### Ready check
 
-!!! tip ":lucide-cable:&nbsp; Connect the QT Py device to your workstation with USB"
+!!! tip ":lucide-cable:{ .lg .middle }&nbsp; Connect the QT Py device to your workstation with USB"
 
 ```pwsh
 # Get latest from upstream
@@ -138,7 +138,7 @@ uv run poe fix
 
 !!! info "Use `qtpy-datalogger connect --port COMxx` to monitor the main run loop on the QT Py node"
 
-!!! tip ":lucide-cable: Connect the QT Py device to your workstation with USB"
+!!! tip ":lucide-cable:{ .lg .middle }&nbsp; Connect the QT Py device to your workstation with USB"
 
 ```pwsh
 # ✍️ Save source code changes
@@ -185,39 +185,39 @@ Design documents for this project are in the wiki under the [**Design Doc X**](h
 
 ### For support libraries
 
-| Name            | Purpose                                                         | Link |
-|-----------------|-----------------------------------------------------------------|------|
-|                 |                                                                 |      |
-| **Host PC**     |                                                                 |      |
-| Python          | :fontawesome-solid-worm:{ .qtpy }&nbsp;                Language | [python.org](https://docs.python.org/3.11/index.html) |
-|                 | :lucide-book-open-text:&nbsp;                Language reference | [python.org](https://docs.python.org/3.11/reference/index.html) |
-|                 | :lucide-library-big:&nbsp;                     Standard library | [python.org](https://docs.python.org/3.11/library/index.html) |
-| uv              | :fontawesome-solid-gear:&nbsp;                        Core tool | [astral.sh](https://docs.astral.sh/uv/) |
-| poe             | :fontawesome-solid-gear:&nbsp;                        Core tool | [natn.io](https://poethepoet.natn.io/index.html) |
-| ruff            | :fontawesome-solid-microscope:&nbsp;              Code analyzer | [astral.sh](https://docs.astral.sh/ruff/) |
-| pyright         | :fontawesome-solid-microscope:&nbsp;              Code analyzer | [github.io](https://microsoft.github.io/pyright) |
-| pytest          | :fontawesome-solid-flask:&nbsp;                     Test runner | [pytest.org](https://docs.pytest.org/en/stable/) |
-| zensical        | :fontawesome-solid-book:&nbsp;                    Documentation | [zensical.org](https://zensical.org/docs/get-started/) |
-| click           | :fontawesome-solid-terminal:&nbsp;       Command line interface | [palletsprojects.com](https://click.palletsprojects.com/en/stable/) |
-| pySerial        | :fontawesome-solid-square-binary:&nbsp;          Serial port IO | [readthedocs.io](https://pyserial.readthedocs.io/en/stable/pyserial.html) |
-| wmi             | :fontawesome-brands-windows:&nbsp;    Windows system inspection | [me.uk](https://timgolden.me.uk/python/wmi/contents.html) |
-| psutil          | :fontawesome-solid-toolbox:&nbsp;  System and process utilities | [readthedocs.io](https://psutil.readthedocs.io/en/stable/) |
-| gmqtt           | :fontawesome-solid-envelope:&nbsp;                  MQTT client | [github.com](https://github.com/wialon/gmqtt) |
-| mosquitto       | :fontawesome-solid-satellite-dish:&nbsp;            MQTT server | [mosquitto.org](https://mosquitto.org/) |
-| ttkbootstrap    | :fontawesome-solid-arrow-pointer:&nbsp;           GUI extension | [readthedocs.io](https://ttkbootstrap.readthedocs.io/en/latest/) |
-| pandas          | :fontawesome-solid-table:&nbsp;                 Data processing | [pydata.org](https://pandas.pydata.org/docs/) |
-| matplotlib      | :fontawesome-solid-chart-line:&nbsp;                   Plotting | [matplotlib.org](https://matplotlib.org/stable/) |
-| circup          | :fontawesome-solid-microchip:&nbsp;                  QT Py tool | [readthedocs.io](https://circup.readthedocs.io/en/stable/) |
-|                 |                                                                 |      |
-| **Sensor node** |                                                                 |      |
-| MicroPython     | :fontawesome-solid-microchip:&nbsp;                  Supervisor | [micropython.org](https://docs.micropython.org/en/v1.23.0/genrst/index.html) |
-| CircuitPython   | :fontawesome-solid-worm:{ .qtpy }&nbsp;                Language | [adafruit.com](https://learn.adafruit.com/welcome-to-circuitpython/overview) |
-|                 | :lucide-library-big:&nbsp;                     Standard library | [circuitpython.org](https://docs.circuitpython.org/en/stable/docs/library/index.html) |
-|                 | :lucide-blocks:&nbsp;                              Core modules | [circuitpython.org](https://docs.circuitpython.org/en/stable/shared-bindings/index.html) |
-| Drivers         | :fontawesome-solid-stethoscope:&nbsp;            Sensor support | [circuitpython.org](https://docs.circuitpython.org/projects/bundle/en/stable/drivers.html) |
-| MiniMQTT        | :fontawesome-solid-envelope:&nbsp;                  MQTT client | [circuitpython.org](https://docs.circuitpython.org/projects/minimqtt/en/stable/index.html) |
-| ASCII           | :lucide-binary:&nbsp;               Binary codes for characters | [ss64.com](https://ss64.com/ascii.html) |
-| XTerm           | :fontawesome-solid-keyboard:&nbsp; Code sequences for terminals | [invisible-island.net](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html) |
+| Name            | Purpose                                                                        | Link |
+|-----------------|--------------------------------------------------------------------------------|------|
+|                 |                                                                                |      |
+| **Host PC**     |                                                                                |      |
+| Python          | :fontawesome-solid-worm:{ .lg .qtpy }&nbsp;                           Language | [python.org](https://docs.python.org/3.11/index.html) |
+|                 | :lucide-book-open-text:{ .lg .middle }&nbsp;                Language reference | [python.org](https://docs.python.org/3.11/reference/index.html) |
+|                 | :lucide-library-big:{ .lg }&nbsp;                             Standard library | [python.org](https://docs.python.org/3.11/library/index.html) |
+| uv              | :fontawesome-solid-gear:{ .lg }&nbsp;                                Core tool | [astral.sh](https://docs.astral.sh/uv/) |
+| poe             | :fontawesome-solid-gear:{ .lg }&nbsp;                                Core tool | [natn.io](https://poethepoet.natn.io/index.html) |
+| ruff            | :fontawesome-solid-microscope:{ .lg }&nbsp;                      Code analyzer | [astral.sh](https://docs.astral.sh/ruff/) |
+| pyright         | :fontawesome-solid-microscope:{ .lg }&nbsp;                      Code analyzer | [github.io](https://microsoft.github.io/pyright) |
+| pytest          | :fontawesome-solid-flask:{ .lg }&nbsp;                             Test runner | [pytest.org](https://docs.pytest.org/en/stable/) |
+| zensical        | :fontawesome-solid-book:{ .lg }&nbsp;                            Documentation | [zensical.org](https://zensical.org/docs/get-started/) |
+| click           | :fontawesome-solid-terminal:{ .lg .middle }&nbsp;       Command line interface | [palletsprojects.com](https://click.palletsprojects.com/en/stable/) |
+| pySerial        | :fontawesome-solid-square-binary:{ .lg .middle }&nbsp;          Serial port IO | [readthedocs.io](https://pyserial.readthedocs.io/en/stable/pyserial.html) |
+| wmi             | :fontawesome-brands-windows:{ .lg }&nbsp;            Windows system inspection | [me.uk](https://timgolden.me.uk/python/wmi/contents.html) |
+| psutil          | :fontawesome-solid-toolbox:{ .lg .middle }&nbsp;  System and process utilities | [readthedocs.io](https://psutil.readthedocs.io/en/stable/) |
+| gmqtt           | :fontawesome-solid-envelope:{ .lg .middle }&nbsp;                  MQTT client | [github.com](https://github.com/wialon/gmqtt) |
+| mosquitto       | :fontawesome-solid-satellite-dish:{ .lg }&nbsp;                    MQTT server | [mosquitto.org](https://mosquitto.org/) |
+| ttkbootstrap    | &nbsp;:fontawesome-solid-arrow-pointer:&nbsp;                    GUI extension | [readthedocs.io](https://ttkbootstrap.readthedocs.io/en/latest/) |
+| pandas          | :fontawesome-solid-table:{ .lg .middle }&nbsp;                 Data processing | [pydata.org](https://pandas.pydata.org/docs/) |
+| matplotlib      | :fontawesome-solid-chart-line:{ .lg .middle }&nbsp;                   Plotting | [matplotlib.org](https://matplotlib.org/stable/) |
+| circup          | :fontawesome-solid-microchip:{ .lg .middle }&nbsp;                  QT Py tool | [readthedocs.io](https://circup.readthedocs.io/en/stable/) |
+|                 |                                                                                |      |
+| **Sensor node** |                                                                                |      |
+| MicroPython     | :fontawesome-solid-microchip:{ .lg .middle }&nbsp;                  Supervisor | [micropython.org](https://docs.micropython.org/en/v1.23.0/genrst/index.html) |
+| CircuitPython   | :fontawesome-solid-worm:{ .lg .qtpy }&nbsp;                           Language | [adafruit.com](https://learn.adafruit.com/welcome-to-circuitpython/overview) |
+|                 | :lucide-library-big:{ .lg }&nbsp;                             Standard library | [circuitpython.org](https://docs.circuitpython.org/en/stable/docs/library/index.html) |
+|                 | :lucide-blocks:{ .lg }&nbsp;                                      Core modules | [circuitpython.org](https://docs.circuitpython.org/en/stable/shared-bindings/index.html) |
+| Drivers         | :fontawesome-solid-stethoscope:{ .lg .middle }&nbsp;            Sensor support | [circuitpython.org](https://docs.circuitpython.org/projects/bundle/en/stable/drivers.html) |
+| MiniMQTT        | :fontawesome-solid-envelope:{ .lg .middle }&nbsp;                  MQTT client | [circuitpython.org](https://docs.circuitpython.org/projects/minimqtt/en/stable/index.html) |
+| ASCII           | :lucide-binary:{ .lg .middle }&nbsp;               Binary codes for characters | [ss64.com](https://ss64.com/ascii.html) |
+| XTerm           | :fontawesome-solid-keyboard:{ .lg .middle }&nbsp; Code sequences for terminals | [invisible-island.net](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html) |
 
 ## Pull requests and Issues
 

--- a/docs/eng/intro/python.md
+++ b/docs/eng/intro/python.md
@@ -1,0 +1,199 @@
+---
+icon: fontawesome/brands/python
+tags:
+  - Develop
+  - Introduction
+  - Python
+---
+
+# Python
+
+## Installation
+
+### Outline
+
+!!! success "Order is important because each step relies on a previous one"
+
+1. **Disable** the Python aliases included with Windows because they interfere with these tools
+1. Install the tool **`uv`**. We selected it because it efficiently
+    - installs and switches between any version of Python
+    - manages dependencies for Python projects
+    - installs Python tools as commands
+1. Install **Python**
+
+Further reading on this Python tooling, its uses, and how it works:
+
+- [**uv**: A Complete Guide]
+    - Explains the efficiencies and convenient workflows in `uv`
+- [Python Virtual Environments: A Primer]
+    - Explains what Python virtual environments are, why they are useful, and how they work
+
+
+!!! info "Why we use `uv run ...`"
+    - `uv` manages the virtual environment and its commands for the project **automatically**
+    - `uv run ...` activates the environment for the command that follows
+    - `uv` invokes these managed commands and won't use a system-wide tool of the same name by accident
+
+### Disable Python aliases
+
+1. Open the **Windows Settings** app and navigate to:
+
+    - **:fontawesome-solid-gear:&nbsp; Settings :lucide-arrow-right: Apps :lucide-arrow-right: Advanced app settings :lucide-arrow-right: App execution aliases**
+
+1. Scroll down the list and **disable** these two entries:
+
+    | Name              | Detail        |
+    |-------------------|---------------|
+    | **App Installer** | `python.exe`  |
+    | **App Installer** | `python3.exe` |
+
+### Install uv
+
+Open PowerShell in Windows Terminal and [install **uv**] with `winget`.
+
+```pwsh
+# Install with winget
+winget install --exact --id=astral-sh.uv
+
+# Confirm that uv has been installed
+uv self version
+```
+
+### Install Python
+
+Open PowerShell and [use **uv**] to install Python.
+
+```pwsh
+# Show the available versions of Python
+uv python list
+
+# Install the latest release of a Python version
+uv python install 3.11
+
+# Set the default version of Python
+uv pin --global 3.11
+
+# Get the active version of Python
+uv python find --show-version
+
+# Show all installed and selectable versions
+uv python list --only-installed
+```
+
+## Testing
+
+This project focuses on writing and running tests that exercise either entire features or single functions.
+As bugs are fixed, we add tests that confirm the bug remains fixed.
+
+### Acceptance testing
+
+Acceptance tests validate a use-case or workflow for a feature.
+They determine whether a user would find the behavior of the code _acceptable_.
+
+### Unit testing
+
+Unit tests validate the outcome from running a function.
+They determine whether the code returns the correct output for the specified input.
+Input values in tests may be purposefully incorrect or inapplicable to validate that the code correctly handles error cases.
+
+### pytest
+
+We use the [tool **pytest**] to run all of the project's tests.
+
+```pwsh
+# Run the tests
+uv run pytest
+
+# Print more information about failures
+uv run pytest --verbose
+```
+
+The Python extension in VS Code automatically [discovers the tests] for this project and lists them in the testing side panel.
+In this view, you can also run tests and debug them.
+
+## Analyzers
+
+This project focuses on writing readable and unsurprising code.
+We run format, structure, and type analysis tools to identify code that doesn't match Python convention.
+
+### ruff
+
+We use the [tool **ruff**] to check and fix [format] and [structure] problems.
+
+**Analyze**
+
+```pwsh
+# Find differences from Python convention
+uv run ruff check
+
+# Find white space and line length problems
+uv run ruff format --diff
+
+# Show an explanation and examples for a violation
+uv run ruff rule Z123
+
+# Pipe to the tool 'mdv' to format the explanation
+# - Install it with 'uv tool install mdv'
+uv run ruff rule Z123 | mdv -
+```
+
+**Fix**
+
+```pwsh
+# Fix differences from Python convention
+uv run ruff check --fix
+
+# Apply formatting rules
+uv run ruff format
+```
+
+The Python extension in VS Code can identify these problems and often has suggested fixes.
+
+### pyright
+
+We use the [tool **pyright**] to check that functions accept and return [compatible types and variables].
+
+**Analyze**
+
+```pwsh
+# Find incompatible or incorrect uses of variables and classes
+uv run pyright
+```
+
+**Fix**
+
+Fixes are made by hand because `pyright` does not have a fix option.
+However, the Python extension in VS Code can identify these problems and often has suggested fixes.
+
+## poe
+
+The [tool **poe**] makes running the tests and analyzers easier because we use [sequence tasks] that call `pytest`, `ruff`, and `pyright` with their parameters.
+
+
+```pwsh
+# Runs 'pytest'
+uv run poe test
+
+# Runs 'ruff check'  then  'ruff format --diff'  then  'pyright --dependencies'
+uv run poe lint
+
+# Runs 'ruff check --fix'  then  'ruff format'
+uv run poe fix
+```
+
+[**uv**: A Complete Guide]: https://pydevtools.com/handbook/explanation/uv-complete-guide/
+[Python Virtual Environments: A Primer]: https://realpython.com/python-virtual-environments-a-primer/
+
+[install **uv**]: https://docs.astral.sh/uv/getting-started/installation/#winget
+[use **uv**]: https://docs.astral.sh/uv/guides/install-python/#installing-a-specific-version
+
+[tool **pytest**]: https://docs.pytest.org/en/stable/
+[discovers the tests]: https://code.visualstudio.com/docs/python/testing#_test-discovery
+[tool **ruff**]: https://docs.astral.sh/ruff/
+[structure]: https://docs.astral.sh/ruff/linter/
+[format]: https://docs.astral.sh/ruff/formatter/
+[tool **pyright**]: https://microsoft.github.io/pyright/#/type-concepts
+[compatible types and variables]: https://microsoft.github.io/pyright/#/features
+
+[tool **poe**]: https://poethepoet.natn.io/index.html
+[sequence tasks]: https://poethepoet.natn.io/tasks/task_types/sequence.html

--- a/docs/eng/intro/recap.md
+++ b/docs/eng/intro/recap.md
@@ -1,0 +1,94 @@
+---
+icon: lucide/message-square-quote
+tags:
+  - Develop
+  - Introduction
+  - Recap
+---
+
+# Recap
+
+All the steps for tool installation and environment initialization are on this page.
+
+- [Guides](/eng/intro/tools) -- tool installation
+- [Develop](/develop) -- environment initialization
+
+Visit the **Develop** page for [Workflows](/develop/#workflows) and [References](/develop/#references).
+
+## Recipe
+
+```pwsh
+# Install VS Code
+winget install --exact --id=Microsoft.VisualStudioCode
+winget install --exact --id=Microsoft.VisualStudioCode.CLI
+
+# Install VS Code extensions
+code --install-extension  bierner.github-markdown-preview
+code --install-extension  charliermarsh.ruff
+code --install-extension  donjayamanne.git-extension-pack
+code --install-extension  ms-python.python
+code --install-extension  ms-toolsai.jupyter
+code --install-extension  tamasfe.even-better-toml
+
+# Install Windows Terminal
+winget install --exact --id=Microsoft.WindowsTerminal
+
+# Install PowerShell
+winget install --exact --id=Microsoft.PowerShell
+
+# Install ScreeToGif
+winget install --exact --id=NickeManarin.ScreenToGif
+
+# Install git
+winget install --exact --id=Git.Git
+
+# Install GitHub Desktop
+winget install --exact --id=GitHub.GitHubDesktop
+```
+
+!!! failure "Before continuing, [disable](/eng/intro/python/#disable-python-aliases) the Python aliases in Windows Settings"
+
+```pwsh
+# Install uv
+winget install --exact --id=astral-sh.uv
+
+# Install the latest release of a Python version
+uv python install 3.11
+
+# Set the default version of Python
+uv pin --global 3.11
+
+# Clone from GitHub
+git clone https://github.com/wireddown/qtpy-datalogger.git
+cd qtpy-datalogger
+
+# Install the package's dependencies
+uv sync
+
+# Confirm GUI component readiness
+uv run qtpy-datalogger run data-viewer
+
+# Install an MQTT broker
+winget install --exact --id=EclipseFoundation.Mosquitto
+```
+
+!!! failure "Before continuing, [configure](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-5-MQTT) the MQTT broker"
+
+!!! tip ":lucide-cable:{ .lg .middle }&nbsp; Connect the QT Py device to your workstation with USB"
+
+```pwsh
+# Confirm MQTT server readiness
+uv run qtpy-datalogger server
+
+# Confirm QT Py detection
+uv run qtpy-datalogger connect --discover-only
+
+# Install and configure the sensor node runtime
+uv run qtpy-datalogger equip --secrets -
+
+# Confirm node readiness
+uv run qtpy-datalogger equip --compare
+
+# Send a message to the QT Py over WiFi
+uv run qtpy-datalogger run scanner
+```

--- a/docs/eng/intro/tools.md
+++ b/docs/eng/intro/tools.md
@@ -1,0 +1,157 @@
+---
+icon: lucide/anvil
+tags:
+  - Develop
+  - Introduction
+  - Tools
+---
+
+# Core tools
+
+## Visual Studio Code
+
+Install the [Visual Studio Code] text editor and review the [getting started tutorial]. There are also guides for [using git] and for [developing Python].
+
+We recommend this because it is an excellent and mature general purpose programming application with syntax highlighting, debugging, and extensions.
+
+??? quote "Install with `winget`"
+    ```pwsh
+    winget install --exact --id=Microsoft.VisualStudioCode
+    winget install --exact --id=Microsoft.VisualStudioCode.CLI
+    ```
+
+### Recommended extensions
+
+This table lists useful [VS Code extensions] for this project.
+
+| Link                                  | Reason |
+|---------------------------------------|--------|
+| [donjayamanne.**git-extension-pack**] | :lucide-file-clock:{ .lg }&nbsp; View and search file history <br /> :lucide-folder-git-2:{ .lg }&nbsp; Adds project manager to left-side activity bar |
+| [ms-python.**python**]                | :lucide-signpost:{ .lg }&nbsp; Adds navigation and API suggestions <br /> :lucide-bug-play:{ .lg .middle }&nbsp; Adds Python debugging and refactoring |
+| [bierner.**github-markdown-preview**] | :lucide-text-initial:{ .lg .middle }&nbsp; Apply GitHub's style to your markdown files |
+| [charliermarsh.**ruff**]              | :lucide-brush-cleaning:{ .lg }&nbsp; Lint and format Python code on file-save |
+| [tamasfe.**even-better-toml**]        | :lucide-list-check:{ .lg .middle }&nbsp; Syntax highlighting and validation for `toml` files |
+| [ms-toolsai.**jupyter**]              | :lucide-chart-spline:{ .lg }&nbsp; Use your own venv as a Jupyter kernel |
+
+### Recommended settings
+
+- Enable `editor.smoothScrolling`
+- Enable `diffEditor.experimental.showMoves`
+- Enable `diffEditor.experimental.useTrueInlineView`
+- Enable `files.insertFinalNewline`
+- Enable `files.trimFinalNewlines`
+- Enable `files.trimTrailingWhitespace`
+- Enable `workbench.list.smoothScrolling`
+- Enable `terminal.integrated.copyOnSelection`
+- Enable `terminal.integrated.smoothScrolling`
+- Enable `terminal.integrated.stickyScroll.enabled`
+
+## Windows Terminal
+
+Install the [Windows Terminal] application and configure it for your preferences.
+
+We recommend this because it hosts shells in tabs like a web browser and supports typical copy-paste actions.
+
+??? quote "Install with `winget`"
+    ```pwsh
+    winget install --exact --id=Microsoft.WindowsTerminal
+    ```
+
+### Recommended settings
+
+- Automatically [copy selection to clipboard]
+- [CaskaydiaCove Nerd Font] font face
+
+To use this font in VS Code:
+
+- Set `terminal.integrated.fontFamily`
+- to `CaskaydiaCove Nerd Font Mono`
+
+## PowerShell
+
+Optionally, install [PowerShell]. This new version is named `pwsh` and installs side-by-side with the system's `powershell` console.
+
+We recommend this because it's the newest and fastest shell for Windows.
+
+??? quote "Install with `winget`"
+    ```pwsh
+    winget install --exact --id=Microsoft.PowerShell
+    ```
+
+### Recommended modules
+
+After installing these, apply their usage instructions to the file returned by `$profile`.
+
+- [Oh My Posh]
+- [Terminal Icons]
+
+To use these modules in VS Code:
+
+- Set `terminal.integrated.defaultProfile.windows`
+- to `PowerShell`
+- Apply the same changes to the VS Code profile returned by `$profile`
+
+## ScreenToGif
+
+Optionally, install the [ScreenToGif] application. This tool records both the screen and mouse clicks.
+
+We recommend this because its recordings help demonstrate program behavior.
+
+??? quote "Install with `winget`"
+    ```pwsh
+    winget install --exact --id=NickeManarin.ScreenToGif
+    ```
+
+## Git
+
+Install [Git for Windows] and keep the default options in the installer dialog pages.
+
+Optionally, install [GitHub Desktop] and [authenticate with GitHub].
+
+We recommend GitHub Desktop because it is designed to be an application for git and GitHub actions.
+
+??? quote "Install with `winget`"
+    ```pwsh
+    winget install --exact --id=Git.Git
+    winget install --exact --id=GitHub.GitHubDesktop
+    ```
+
+### Practical exercises
+
+1. Complete the full [pull request workflow tutorial] to create your own profile README from your browser.
+1. Repeat the tutorial [using GitHub Desktop] and update your profile README page.
+1. Repeat the tutorial [using Visual Studio Code] and update your profile README page.
+1. Repeat the tutorial [using git commands] when possible and update your profile README page.
+1. Choose another tutorial from [the GitHub skills] collection.
+
+
+[Visual Studio Code]: https://code.visualstudio.com
+[using git]: https://code.visualstudio.com/docs/sourcecontrol/overview
+[developing Python]: https://code.visualstudio.com/docs/languages/python
+[VS Code extensions]: https://marketplace.visualstudio.com
+[donjayamanne.**git-extension-pack**]: https://marketplace.visualstudio.com/items?itemName=donjayamanne.git-extension-pack
+[ms-python.**python**]: https://marketplace.visualstudio.com/items?itemName=ms-python.python
+[bierner.**github-markdown-preview**]: https://marketplace.visualstudio.com/items?itemName=bierner.github-markdown-preview
+[charliermarsh.**ruff**]: https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff
+[tamasfe.**even-better-toml**]: https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml
+[ms-toolsai.**jupyter**]: https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter
+[getting started tutorial]: https://code.visualstudio.com/docs/getstarted/getting-started
+
+[Windows Terminal]: https://learn.microsoft.com/en-us/windows/terminal/install
+[copy selection to clipboard]: https://learn.microsoft.com/en-us/windows/terminal/customize-settings/interaction#automatically-copy-selection-to-clipboard
+[CaskaydiaCove Nerd Font]: https://learn.microsoft.com/en-us/windows/terminal/tutorials/custom-prompt-setup#install-a-nerd-font
+
+[PowerShell]: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows
+[Oh My Posh]: https://learn.microsoft.com/en-us/windows/terminal/tutorials/custom-prompt-setup#customize-your-powershell-prompt-with-oh-my-posh
+[Terminal Icons]: https://learn.microsoft.com/en-us/windows/terminal/tutorials/custom-prompt-setup#use-terminal-icons-to-add-missing-folder-or-file-icons
+
+[ScreenToGif]: https://www.screentogif.com/downloads
+
+[Git for Windows]: https://gitforwindows.org/
+[GitHub Desktop]: https://desktop.github.com/download/
+[authenticate with GitHub]: https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop
+[pull request workflow tutorial]: https://github.com/skills/introduction-to-github
+[using GitHub Desktop]: https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop#part-3-contributing-to-projects-with-github-desktop
+[using Visual Studio Code]: https://code.visualstudio.com/docs/sourcecontrol/overview
+[using git commands]: https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
+[the GitHub skills]: https://skills.github.com/

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,13 +9,13 @@ tags:
 
 ## Subsystems
 
-| Function                                           | Input                          | Output                         |
-|----------------------------------------------------|:------------------------------:|:------------------------------:|
-| :lucide-audio-waveform:&nbsp; Analog pins          | :lucide-circle-check:{ .qtpy } | :lucide-circle-check:{ .qtpy } |
-| :fontawesome-solid-wave-square:&nbsp; Digital pins | :lucide-circle-check:{ .qtpy } | :lucide-circle-check:{ .qtpy } |
-| :fontawesome-solid-microchip:&nbsp; SPI bus        | :lucide-circle-check:{ .qtpy } | :lucide-circle-check:{ .qtpy } |
-| :fontawesome-solid-microchip:&nbsp; I^2^C bus      | :lucide-circle-check:{ .qtpy } | :lucide-circle-check:{ .qtpy } |
-| :lucide-siren:&nbsp; NeoPixel                      |                                | :lucide-circle-check:{ .🦜 }   |
+| Function                                                          | Input                              | Output                             |
+|-------------------------------------------------------------------|:----------------------------------:|:----------------------------------:|
+| :lucide-audio-waveform:{ .lg .middle }&nbsp; Analog pins          | :lucide-circle-check:{ .lg .qtpy } | :lucide-circle-check:{ .lg .qtpy } |
+| :fontawesome-solid-wave-square:{ .lg .middle }&nbsp; Digital pins | :lucide-circle-check:{ .lg .qtpy } | :lucide-circle-check:{ .lg .qtpy } |
+| :fontawesome-solid-microchip:{ .lg .middle }&nbsp; SPI bus        | :lucide-circle-check:{ .lg .qtpy } | :lucide-circle-check:{ .lg .qtpy } |
+| :fontawesome-solid-microchip:{ .lg .middle }&nbsp; I^2^C bus      | :lucide-circle-check:{ .lg .qtpy } | :lucide-circle-check:{ .lg .qtpy } |
+| :lucide-siren:{ .lg }&nbsp; NeoPixel                              |                                    | :lucide-circle-check:{ .lg .🦜 }   |
 
 ## Connectivity
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
 <div class="grid cards" markdown>
 
--   :fontawesome-solid-microchip:{ .middle }&nbsp; __Use every subsystem__
+-   :fontawesome-solid-microchip:{ .lg .middle .qtpy }&nbsp; __Use every subsystem__
 
     ---
 
@@ -45,7 +45,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
     :octicons-arrow-right-24: [Features](/features)
 
--   :lucide-square-activity:{ .lg .middle }&nbsp; __Adapt to any use case__
+-   :lucide-square-activity:{ .lg .middle .qtpy }&nbsp; __Adapt to any use case__
 
     ---
 
@@ -57,7 +57,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
 <div class="grid cards" markdown>
 
--   :fontawesome-solid-image:{ .middle }&nbsp; __GUI applications__
+-   :lucide-chart-spline:{ .lg .middle .qtpy }&nbsp; __GUI applications__
 
     ---
 
@@ -65,7 +65,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
     :octicons-arrow-right-24: [Gallery](/gallery)
 
--   :material-clock-fast:{ .lg .middle }&nbsp; __Set up in 5 minutes__
+-   :lucide-zap:{ .lg .middle .qtpy }&nbsp; __Set up in 5 minutes__
 
     ---
 

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -1,0 +1,62 @@
+---
+icon: lucide/radar
+tags:
+  - Help
+  - Troubleshoot
+---
+
+# Troubleshoot
+
+## Runtime environment
+
+If you're using the package but something isn't working correctly, open a PowerShell window in the package's folder and run these commands to show information about its environment.
+
+```pwsh
+# Activate the package's environment
+.\.venv\Scripts\activate.ps1
+
+# Connect the QT Py with USB and confirm detection
+qtpy-datalogger connect --discover-only
+
+# Detect and show differences between the QT Py and the package
+qtpy-datalogger equip --compare
+
+# Confirm MQTT server readiness
+qtpy-datalogger server
+
+# Find and communicate with the QT Py over the network
+qtpy-datalogger run scanner
+```
+
+## Development environment
+
+If you're customizing or contributing, run these commands to show information about the tools' versions and configuration.
+
+```pwsh
+# What are the environment variables?
+env
+
+# Is a command callable? Where is it?
+Get-Command uv
+
+# Show details about uv
+uv self version
+
+# List the commands installed by uv
+uv tool list
+
+# Show installed and selectable versions of Python
+uv python list --only-installed
+
+# Show the active version of Python in this folder
+uv python find --show-version
+
+# Confirm dependencies are satisfied
+uv sync --check
+
+# Show the packages installed in this Python environment
+uv tree
+
+# Show VS Code extension information
+code --list-extensions --show-versions
+```

--- a/zensical.toml
+++ b/zensical.toml
@@ -59,6 +59,11 @@ nav = [
   ] },
   { "Develop" = [
     { "Develop" = "develop.md" },
+    { "Guides" = [
+      { "Tools" = "eng/intro/tools.md" },
+      { "Python" = "eng/intro/python.md" },
+      { "Recap" = "eng/intro/recap.md" },
+      ] },
   ] },
   { "Legacy system" = "legacy/README.md" },
   { "Governance" = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -326,6 +326,8 @@ link = "https://github.com/wireddown"
 # Custom overrides
 # ----------------------------------------------------------------------------
 [project.theme.icon.admonition]
+info = "lucide/message-circle-heart"
+question = "fontawesome/solid/circle-question"
 tip = "lucide/arrow-big-right"
 
 # ----------------------------------------------------------------------------

--- a/zensical.toml
+++ b/zensical.toml
@@ -54,6 +54,9 @@ nav = [
     { "Get started" = "get-started.md" },
     { "Customize" = "customize.md" },
   ] },
+  { "Help" = [
+    { "Troubleshoot" = "troubleshoot.md" },
+  ] },
   { "Develop" = [
     { "Develop" = "develop.md" },
   ] },


### PR DESCRIPTION
## Summary

This PR adds two new page trees to the documentation site: **Help** and **Guides**
- **Help**
  - Troubleshoot -- Use [Troubleshooting](https://github.com/wireddown/qtpy-datalogger/wiki/Troubleshooting) from the wiki
- Develop
  - **Guides**
    - Tools -- Use [Tools](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-1-Tools) and [Git](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-2-Git) from the wiki
    - Python -- Use [Python](https://github.com/wireddown/qtpy-datalogger/wiki/Walkthrough-3-Python) from the wiki
    - Recap -- Compactly explain onboarding

This PR also makes some visual improvements for icon and color use.

## Design

- Add new page files and navigation structure
- Use `{ .lg .middle }` to nudge icons

**`develop.md`**
- Add GUI ready checks

## Screenshots or logs

### Navigation

<img width="494" height="632" alt="image" src="https://github.com/user-attachments/assets/9f03f190-99e7-48ab-8ee7-3d47e9e87ab9" />

### Home page

<img width="1004" height="536" alt="image" src="https://github.com/user-attachments/assets/83431831-9643-4edc-86f4-f5db1850bddc" />

### Features page

<img width="1000" height="586" alt="image" src="https://github.com/user-attachments/assets/59b41ce2-7499-4e48-9500-2df192df251e" />

### Recap page

<img width="997" height="630" alt="image" src="https://github.com/user-attachments/assets/cf9281b0-61f1-4c9c-8472-431cd9bdeff6" />

## Testing

See screenshots above.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
