### PR TITLE
Docs: Fix misdirecting links

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -13,7 +13,7 @@ This is a crash course introducing the tools and libraries used in the project.
 
 ??? question "New to git and Python?"
 
-    If these tools and commands are not on your system, follow the introductory [Guide pages](/eng/intro/tools).
+    If these tools and commands are not on your system, follow the introductory [Guide pages](eng/intro/tools).
 
 ### Requirements
 

--- a/docs/eng/intro/recap.md
+++ b/docs/eng/intro/recap.md
@@ -10,10 +10,10 @@ tags:
 
 All the steps for tool installation and environment initialization are on this page.
 
-- [Guides](/eng/intro/tools) -- tool installation
-- [Develop](/develop) -- environment initialization
+- [Guides](eng/intro/tools) -- tool installation
+- [Develop](develop) -- environment initialization
 
-Visit the **Develop** page for [Workflows](/develop/#workflows) and [References](/develop/#references).
+Visit the **Develop** page for [Workflows](develop/#workflows) and [References](develop/#references).
 
 ## Recipe
 
@@ -46,7 +46,7 @@ winget install --exact --id=Git.Git
 winget install --exact --id=GitHub.GitHubDesktop
 ```
 
-!!! failure "Before continuing, [disable](/eng/intro/python/#disable-python-aliases) the Python aliases in Windows Settings"
+!!! failure "Before continuing, [disable](eng/intro/python/#disable-python-aliases) the Python aliases in Windows Settings"
 
 ```pwsh
 # Install uv

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
     Read and write both **analog** and **digital** pins. Control **SPI** and **I^2^C** peripherals. Blink the **NeoPixel** :lucide-siren:{ .🦜 }
 
-    :octicons-arrow-right-24: [Features](/features)
+    :octicons-arrow-right-24: [Features](features)
 
 -   :lucide-square-activity:{ .lg .middle .qtpy }&nbsp; __Adapt to any use case__
 
@@ -51,7 +51,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
     Use the app API to deploy custom code for remote acquisition and control.
 
-    :octicons-arrow-right-24: [Customize](/customize)
+    :octicons-arrow-right-24: [Customize](customize)
 
 </div>
 
@@ -63,7 +63,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
     Includes built-in GUI applications for detecting sensor nodes and viewing data.
 
-    :octicons-arrow-right-24: [Gallery](/gallery)
+    :octicons-arrow-right-24: [Gallery](gallery)
 
 -   :lucide-zap:{ .lg .middle .qtpy }&nbsp; __Set up in 5 minutes__
 
@@ -71,7 +71,7 @@ The PC host controls and communicates with any number of sensor nodes on the wir
 
     Install `qtpy-datalogger` with `pip` and get up and running in minutes.
 
-    :octicons-arrow-right-24: [Get started](/get-started)
+    :octicons-arrow-right-24: [Get started](get-started)
 
 </div>
 


### PR DESCRIPTION
## Summary

This PR corrects internal links so they do not misdirect browsers to the root downtothewire.io/ URL.

## Design

Use relative links to other pages.

## Screenshots or logs

None.

## Testing

We can test this once the changes are in `main`.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] ~~Tests passed~~
- [x] ~~Analyzers passed~~
- [x] ~~Ready to complete~~
