### PR TITLE
pyproject.toml: Complete switching to ty type checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Run ty
       run: |
-        uv run ty check --python-version ${{ matrix.python_version }} --output-format github
+        uv run ty check --python-version ${{ matrix.python_version }} --output-format github --verbose
         uv run ty check --python-version ${{ matrix.python_version }} --output-format junit >> junit/ty-check-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
         echo '## :microscope: ty results' >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,13 @@ jobs:
         echo '```' >> $env:GITHUB_STEP_SUMMARY
 
     - name: Run pytest
-      run: uv run pytest --verbose --junit-xml=junit/pytest-results-${{ runner.os }}-${{ matrix.python_version }}.xml
+      run: uv run pytest --verbose --junit-xml=junit/pytest-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
 
     - name: Run ruff check
       id: ruff-check
       run: |
         uv run ruff check --output-format github
-        uv run ruff check --output-format junit --output-file junit/ruff-check-results-${{ runner.os }}-${{ matrix.python_version }}.xml
+        uv run ruff check --output-format junit --output-file junit/ruff-check-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
       if: always()
 
     - name: Run ruff format --diff
@@ -83,11 +83,11 @@ jobs:
 
     - name: Run ty
       run: |
-        uv run ty check --output-format github
-        uv run ty check --output-format junit --output-file junit/ty-check-results-${{ runner.os }}-${{ matrix.python_version }}.xml
+        uv run ty check --python-version ${{ matrix.python_version }} --output-format github
+        uv run ty check --python-version ${{ matrix.python_version }} --output-format junit >> junit/ty-check-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
         echo '## :microscope: ty results' >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
-        uv run ty check --output-format concise >> $env:GITHUB_STEP_SUMMARY
+        uv run ty check --python-version ${{ matrix.python_version }} --output-format concise >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
       if: always()
 
@@ -135,7 +135,7 @@ jobs:
       id: upload-doc-site
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: qtpy-datalogger-documentation-site-${{ runner.os }}-py${{ matrix.python_version }}
+        name: qtpy-datalogger-documentation-site-py${{ matrix.python_version }}-${{ runner.os }}
         path: site/
       if: always()
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -261,7 +261,7 @@ Design documents for this project are in the wiki under the [**Design Doc X**](h
 | uv              | :fontawesome-solid-gear:{ .lg }&nbsp;                                Core tool | [astral.sh](https://docs.astral.sh/uv/) |
 | poe             | :fontawesome-solid-gear:{ .lg }&nbsp;                                Core tool | [natn.io](https://poethepoet.natn.io/index.html) |
 | ruff            | :fontawesome-solid-microscope:{ .lg }&nbsp;                      Code analyzer | [astral.sh](https://docs.astral.sh/ruff/) |
-| ty              | :fontawesome-solid-microscope:{ .lg }&nbsp;                      Code analyzer | [github.io](https://docs.astral.sh/ty/) |
+| ty              | :fontawesome-solid-microscope:{ .lg }&nbsp;                      Code analyzer | [astral.sh](https://docs.astral.sh/ty/) |
 | pytest          | :fontawesome-solid-flask:{ .lg }&nbsp;                             Test runner | [pytest.org](https://docs.pytest.org/en/stable/) |
 | zensical        | :fontawesome-solid-book:{ .lg }&nbsp;                            Documentation | [zensical.org](https://zensical.org/docs/get-started/) |
 | click           | :fontawesome-solid-terminal:{ .lg .middle }&nbsp;       Command line interface | [palletsprojects.com](https://click.palletsprojects.com/en/stable/) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,14 @@ include = ["src/qtpy_datalogger/sensor_node/snsr/pysh/**"]
 [tool.ty.overrides.rules]
 possibly-unresolved-reference = "ignore"
 
+# Submodule snsr.node.classes uses loose typing rather than full classes to support CircuitPython json constraints
+[[tool.ty.overrides]]
+include = ["src/qtpy_datalogger/sensor_node/snsr/node/classes.py"]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+invalid-return-type = "ignore"
+
 [tool.ty.src]
 exclude = [
     "docs/legacy",


### PR DESCRIPTION
## Summary

This PR completes the series of commits that changes the project's Python typechecker to `ty`.

### ➡️ [**ad3f56c7** .. **4cfa6cdc**](https://github.com/wireddown/qtpy-datalogger/compare/ad3f56c776c50c781968cd4d8fae242f4611c15d..4cfa6cdc05c850f41c011b57a33d5e0ebdadcc15)
🫣 I pushed these commits directly to `main` without a PR
- [**.gitignore:** Add .ruff_cache folder](https://github.com/wireddown/qtpy-datalogger/commit/6d5e4dbbffa4cab04941743d0a940f00197efca6)
- [**pyproject.toml:** Change type checking tool from Pyright to ty](https://github.com/wireddown/qtpy-datalogger/commit/2899ba8c5631e18a4b11ba058fd7c6f9b7505b5e)
- [**develop.md:** Update tool reference from Pyright to ty](https://github.com/wireddown/qtpy-datalogger/commit/9293cec323c093ad2c6db894e9c1c6281432fdb4)
- [**tools.md:** Add link to ty VS Code extension](https://github.com/wireddown/qtpy-datalogger/commit/73f9a7d6103d02070ae91975050a2a19bbdf54cd)
- [**recap.md:** Add install command for ty VS Code extension](https://github.com/wireddown/qtpy-datalogger/commit/a30dd43441c7553af78aa831fe64ae289565d788)
- [**ci.yml:** Rework the Pyright step to use ty](https://github.com/wireddown/qtpy-datalogger/commit/896a9dd148fddee5f1384ff1791729649864e74a)
- [**many:** Remove pyright workaround suppressions because ty correctly detects the type usage at these call sites](https://github.com/wireddown/qtpy-datalogger/commit/9c4993f4d50747909419f82cec18ed3de61dfc59)
- [**many:** Convert genuine Pyright suppressions to ty suppressions](https://github.com/wireddown/qtpy-datalogger/commit/41413ac324d964bb4658b254a846f682f00b20f0)
- [**many:** Add new ty suppressions for uncovered detections](https://github.com/wireddown/qtpy-datalogger/commit/fb044dc999c6fd9dfdfe82e43a36bc711dcda6df)
- [**test_discovery.py:** Fix type hints from ty errors](https://github.com/wireddown/qtpy-datalogger/commit/a3f22188c1c6a65266cce111e35224711d99933d)
- [**pyproject.toml:** Add subtask to 'fix' sequence that runs 'ty check --fix'](https://github.com/wireddown/qtpy-datalogger/commit/6fc96cc9ff8b903048735be10c3e1df7b62c7a47)
- [**python.md:** Rework Pyright section for ty](https://github.com/wireddown/qtpy-datalogger/commit/2120969d9b871bbbd38d6cff3e9f5ca8d6022fdb)
- [**README.md:** Fix MQTT link](https://github.com/wireddown/qtpy-datalogger/commit/4cfa6cdc05c850f41c011b57a33d5e0ebdadcc15)

## Design

- Remove `pyright`
- Add `ty`
- Configure rules and address errors

## Screenshots or logs

- See the checks on the CI workflow

## Testing

- See the checks on the CI workflow

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] Documentation updated
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
