### PR TITLE
network.py: Handle empty messages from de-retained messages

### DIFF
--- a/src/qtpy_datalogger/network.py
+++ b/src/qtpy_datalogger/network.py
@@ -213,6 +213,10 @@ class QTPyController:
             while not parameters_and_sender:
                 topic_and_message = await self.message_queue.get()
                 response_json = topic_and_message.message
+                if not response_json:
+                    # The message is empty when a topic's retained message is cleared
+                    self.message_queue.task_done()
+                    continue
                 response = json.loads(response_json)
                 if "action" in response:
                     payload = node_classes.ActionPayload.from_dict(response)


### PR DESCRIPTION
## Summary

This PR fixes a bug in `**QTPyController**` where calling **`get_matching_result()`** raises a `JSONDecodeError`, but only if the controller called **`clear_retained_group_action()`** at least once beforehand.

### Reproduction

```python
import asyncio

from qtpy_datalogger.network import QTPyController
from qtpy_datalogger.sensor_node.snsr.node.classes import ActionInformation


async def main():
    action = ActionInformation(
        command="custom",
        parameters={"input": "qtpycmd stats"},
        message_id="anyid",
    )

    qtpy_controller = QTPyController.for_localhost_server("anyzone")
    await qtpy_controller.connect_and_subscribe()
    qtpy_controller.post_retained_group_action(action)

    # Prime the bug -- sends an empty message to the group topic
    qtpy_controller.clear_retained_group_action()

    try:
        # Hit the bug
        result, sender = await qtpy_controller.get_matching_result(node_id="notanode", action=action)
        print(f"{sender.descriptor_topic} reponded with {result}")
    except TimeoutError:
        print("no responses")
    await qtpy_controller.disconnect()


asyncio.run(main())
```

Exits with

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Design

- When an MQTT broker clears a retained message, it sends an empty message on the same topic.
- The QTPyController assumes that every message is JSON and fails to parse an empty string.
- **Fix:** do not attempt to parse empty messages.

## Screenshots or logs

Now the reproduction code exits with

```
no responses
```

## Testing

See logs above

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
