### PR TITLE
Host API: Call window.update() to render after presenting an AsyncWindow or AsyncDialog

### DIFF
--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -158,6 +158,7 @@ class AsyncDialog:
         self.root_window.deiconify()  # Render and present
         self.initial_focus.focus_set()
         self.root_window.wait_visibility()
+        self.root_window.update()
 
         if behavior == DialogBehavior.Modal:
             self.root_window.grab_set()
@@ -235,7 +236,8 @@ class AsyncWindow:
         """Show the window and cooperatively run with asyncio."""
         self.on_show()
         self.root_window.deiconify()
-        self.root_window.wait_visibility(self.root_window)
+        self.root_window.wait_visibility()
+        self.root_window.update()
 
         while self.should_run_loop:
             await asyncio.sleep(0)


### PR DESCRIPTION
## Summary

This PR fixes a "white box" presentation glitch for apps that immediately do IO-bound operations when shown.

## Design

Call `update()` on the root window before entering the run loop to allow the UI to finish rendering.

## Screenshots or logs

_None -- done with local testing trying to do IO discovery_

## Testing

_None -- done with local testing trying to do IO discovery_

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
