### PR TITLE
Host API: Add method to QTPyController that waits for any node to respond

### DIFF
--- a/src/qtpy_datalogger/network.py
+++ b/src/qtpy_datalogger/network.py
@@ -208,7 +208,7 @@ class QTPyController:
         parameters_and_sender = ()
         other_messages = []
         action_id = action.message_id
-        logger.debug(f"Monitoring MQTT messages for the '{action_id}' result from '{node_id}'")
+        logger.debug(f"Monitoring MQTT messages for result matching '{action_id}' from node '{node_id}'")
         async with asyncio.timeout(timeout):
             while not parameters_and_sender:
                 topic_and_message = await self.message_queue.get()
@@ -223,7 +223,7 @@ class QTPyController:
                     sending_node = node_mqtt.node_from_topic(payload.sender.descriptor_topic)
                     result_id = payload.action.message_id
                     if node_id in (sending_node, "+") and result_id == action_id:
-                        logger.debug(f"Matched result '{payload.action.parameters}'")
+                        logger.debug(f"Matched result from '{sending_node}'")
                         parameters_and_sender = (payload.action.parameters, payload.sender)
                     else:
                         other_messages.append(topic_and_message)
@@ -233,6 +233,23 @@ class QTPyController:
         for other_message in other_messages:
             self._requeue_or_discard(other_message)
         return parameters_and_sender
+
+    async def wait_until_matching_node_response(
+        self, action: node_classes.ActionInformation
+    ) -> tuple[dict, node_classes.SenderInformation]:
+        """Cooperatively wait until the first sensor_node responds to the specified action."""
+        result = {}
+        sender = node_classes.SenderInformation.create_empty()
+        sender_id = ""
+        while not sender_id.startswith("node-"):
+            try:
+                result, sender = await self.get_matching_result(node_id="+", action=action, timeout=0)
+                sender_id = node_mqtt.node_from_topic(sender.descriptor_topic)
+                logger.debug(f"Node '{sender_id}' responded with {result}")
+            except TimeoutError:
+                # Expected with no-wait calls (timeout=0), sleep and let the node finish responding
+                await asyncio.sleep(1e-3)
+        return (result, sender)
 
     def post_retained_group_action(self, action: node_classes.ActionInformation) -> None:
         """Publish an action to the group's broadcast topic and retain it."""

--- a/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
@@ -199,6 +199,11 @@ class SenderInformation:
         status_information = StatusInformation.from_dict(dictionary["status"])
         return SenderInformation(dictionary["descriptor_topic"], dictionary["sent_at"], status_information)
 
+    @staticmethod
+    def create_empty() -> "SenderInformation":
+        """Return an empty object. Useful as a sentinel value."""
+        return SenderInformation("", "", StatusInformation("", "", ""))
+
     def as_dict(self) -> dict:
         """Return a dictionary representation."""
         return self.information


### PR DESCRIPTION
## Summary

This PR adds a cooperative, infinite-wait method to **QTPyController** that returns when the first node responds to the specified action.

## Design

**`network.py`**

Add new method
- **`wait_until_matching_node_response()`** -- Cooperatively wait until the first sensor_node responds to the specified action

**`snsr.node.classes.py`**
- Add helper method to create an empty object

## Screenshots or logs

See testing below.

## Testing

**`demo.py`**

```python
import asyncio

from qtpy_datalogger.network import QTPyController
from qtpy_datalogger.sensor_node.snsr.node.classes import ActionInformation


async def main():
    action = ActionInformation(
        command="custom",
        parameters={"input": "qtpycmd stats"},
        message_id="anyid",
    )

    qtpy_controller = QTPyController.for_localhost_server("zone1")
    await qtpy_controller.connect_and_subscribe()
    qtpy_controller.post_retained_group_action(action)
    try:
        # Use the new method here
        result, sender = await qtpy_controller.wait_until_matching_node_response(action=action)
        print(f"{sender.descriptor_topic} responded with {result}")
    except TimeoutError:
        print("no responses")
    qtpy_controller.clear_retained_group_action()
    await qtpy_controller.disconnect()


asyncio.run(main())
```

**`> uv run python demo.py`**
```
qtpy/v1/zone1/node-4f21afa56341-0/$DESCRIPTOR responded with {'output': '61.375 kB used | 1951.625 kB free | 12971.77 s uptime', 'complete': True}
```

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
