### PR TITLE
Host API: Add submodule for UART communication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,7 @@ jobs:
     - name: Run ruff format
       id: ruff-format
       run: |
-        uv run ruff format --preview --check --output-format github
-        uv run ruff format --preview --check --output-format junit > junit/ruff-format-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
+        uv run ruff format --check
       if: always()
 
     - name: Run ruff format --diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       id: ruff-format
       run: |
         uv run ruff format --preview --check --output-format github
-        uv run ruff format --preview --check --output-format --output-file junit/ruff-format-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
+        uv run ruff format --preview --check --output-format junit
       if: always()
 
     - name: Run ruff format --diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
         uv run ruff check --output-format junit --output-file junit/ruff-check-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
       if: always()
 
+    - name: Run ruff format
+      id: ruff-format
+      run: |
+        uv run ruff format --check --output-format github
+        uv run ruff format --check --output-format --output-file junit/ruff-format-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
+      if: always()
+
     - name: Run ruff format --diff
       run: |
         uv run ruff format --diff
@@ -78,7 +85,7 @@ jobs:
         echo '```' >> $env:GITHUB_STEP_SUMMARY
         echo ' - :green_circle: Use `ruff format` to fix errors' >> $env:GITHUB_STEP_SUMMARY
         echo '' >> $env:GITHUB_STEP_SUMMARY
-      if: ${{ failure() && steps.ruff-check.conclusion == 'failure' }}
+      if: ${{ failure() && steps.ruff-format.conclusion == 'failure' }}
       continue-on-error: true
 
     - name: Run ty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
     - name: Run ruff format
       id: ruff-format
       run: |
-        uv run ruff format --check --output-format github
-        uv run ruff format --check --output-format --output-file junit/ruff-format-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
+        uv run ruff format --preview --check --output-format github
+        uv run ruff format --preview --check --output-format --output-file junit/ruff-format-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
       if: always()
 
     - name: Run ruff format --diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       id: ruff-format
       run: |
         uv run ruff format --preview --check --output-format github
-        uv run ruff format --preview --check --output-format junit
+        uv run ruff format --preview --check --output-format junit > junit/ruff-format-results-py${{ matrix.python_version }}-${{ runner.os }}.xml
       if: always()
 
     - name: Run ruff format --diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,10 @@ jobs:
         echo '```' >> $env:GITHUB_STEP_SUMMARY
         uv run ruff check --output-format grouped >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
-        echo '- :green_circle: Use `poe fix` to apply safe fixes' >> $env:GITHUB_STEP_SUMMARY
-        echo '- :warning: Use `ruff check --fix --unsafe-fixes` to apply experimental fixes' >> $env:GITHUB_STEP_SUMMARY
-        echo '- :book: Use `ruff rule Z123 | mdv -` to see examples' >> $env:GITHUB_STEP_SUMMARY
+        echo 'If there are errors:' >> $env:GITHUB_STEP_SUMMARY
+        echo '- :green_circle: Use `uv run poe fix` to apply safe fixes' >> $env:GITHUB_STEP_SUMMARY
+        echo '- :warning: Use `uv run ruff check --fix --unsafe-fixes` to apply experimental fixes' >> $env:GITHUB_STEP_SUMMARY
+        echo '- :book: Use `uv run ruff rule Z123 | mdv -` to see examples' >> $env:GITHUB_STEP_SUMMARY
         echo '  - `mdv` is a [terminal viewer](https://github.com/axiros/terminal_markdown_viewer) for markdown' >> $env:GITHUB_STEP_SUMMARY
         echo '  - Full list on https://docs.astral.sh/ruff/rules/' >> $env:GITHUB_STEP_SUMMARY
         echo '' >> $env:GITHUB_STEP_SUMMARY
@@ -82,7 +83,8 @@ jobs:
         echo '```diff' >> $env:GITHUB_STEP_SUMMARY
         uv run ruff format --diff >> $env:GITHUB_STEP_SUMMARY
         echo '```' >> $env:GITHUB_STEP_SUMMARY
-        echo ' - :green_circle: Use `ruff format` to fix errors' >> $env:GITHUB_STEP_SUMMARY
+        echo 'If there are errors:' >> $env:GITHUB_STEP_SUMMARY
+        echo ' - :green_circle: Use `uv run ruff format` to fix errors' >> $env:GITHUB_STEP_SUMMARY
         echo '' >> $env:GITHUB_STEP_SUMMARY
       if: ${{ failure() && steps.ruff-format.conclusion == 'failure' }}
       continue-on-error: true

--- a/src/qtpy_datalogger/discovery.py
+++ b/src/qtpy_datalogger/discovery.py
@@ -10,7 +10,6 @@ Supported connection types
 """
 
 import asyncio
-import contextlib
 import dataclasses
 import logging
 import os
@@ -19,11 +18,9 @@ import sys
 from enum import StrEnum
 
 import click
-import serial
 import toml
-from serial.tools import miniterm as mt
 
-from qtpy_datalogger import network
+from qtpy_datalogger import network, uart
 
 from .datatypes import CaptionCorrections, ConnectionTransport, Default, DetailKey, ExitCode, SnsrNotice, SnsrPath
 
@@ -117,7 +114,7 @@ def handle_connect(behavior: Behavior, group_id: str, node: str, port: str) -> N
         raise SystemExit(ExitCode.COM1_Failure)
 
     if communication_transport == ConnectionTransport.UART_Serial:
-        open_session_on_port(port)
+        uart.open_session_on_port(port)
     elif communication_transport == ConnectionTransport.MQTT_WiFi:
         network.open_session_on_node(group_id, node)
         group_option = "" if group_id == Default.MqttGroup else f"--group {group_id}"
@@ -132,7 +129,7 @@ async def discover_qtpy_devices_async(group_id: str) -> dict[str, QTPyDevice]:
     logger.info("Discovering serial ports")
     logger.info(f"Scanning the network for sensor_node devices in group '{group_id}'")
     discovered_serial_ports, discovered_nodes = await asyncio.gather(
-        asyncio.to_thread(_query_ports_from_serial),
+        asyncio.to_thread(uart.query_ports_from_serial),
         network.query_nodes_from_mqtt_async(group_id),
     )
 
@@ -148,7 +145,7 @@ def discover_qtpy_devices(group_id: str) -> dict[str, QTPyDevice]:
     """Scan for QT Py devices and return a dictionary of QTPyDevice instances indexed by serial_number."""
     # A QT Py COM port has a serial number
     logger.info("Discovering serial ports")
-    discovered_serial_ports = _query_ports_from_serial()
+    discovered_serial_ports = uart.query_ports_from_serial()
 
     # And its disk drive uses the same serial number
     logger.info("Discovering disk volumes")
@@ -223,62 +220,6 @@ def _process_query_results(
     return qtpy_devices
 
 
-def open_session_on_port(port: str) -> None:
-    """Open a terminal connection to the specified serial port."""
-    serial_options = {
-        "url": port,
-        "baudrate": 115200,
-        "bytesize": 8,
-        "parity": "N",
-        "stopbits": 1,
-        "rtscts": False,
-        "xonxoff": False,
-        "do_not_open": True,
-    }
-    logger.debug(serial_options)
-    com_port = serial.serial_for_url(**serial_options)
-
-    if not hasattr(com_port, "cancel_read"):
-        # Enable timeout for alive flag polling if cancel_read is not available
-        com_port.timeout = 1
-
-    if isinstance(com_port, serial.Serial):
-        com_port.exclusive = True
-
-    com_port.open()
-
-    miniterm_options = {
-        "serial_instance": com_port,
-        "echo": False,
-        "eol": "crlf",
-        "filters": ["direct"],
-    }
-    logger.debug(miniterm_options)
-    miniterm = mt.Miniterm(**miniterm_options)
-
-    miniterm.exit_character = "\x1d"
-    miniterm.menu_character = "\x14"
-    miniterm.raw = False
-    miniterm.set_rx_encoding("UTF-8")
-    miniterm.set_tx_encoding("UTF-8")
-
-    quit_command = mt.key_description(miniterm.exit_character)
-    help_command = mt.key_description(miniterm.menu_character)
-    logger.info(
-        f"---   Miniterm on {miniterm.serial.name}   Opts: {miniterm.serial.baudrate},{miniterm.serial.bytesize},{miniterm.serial.parity},{miniterm.serial.stopbits}    ---"
-    )
-    logger.info(f"---   Quit: {quit_command}        Help: {help_command} then H   ---")
-
-    miniterm.start()
-    with contextlib.suppress(KeyboardInterrupt):
-        miniterm.join(True)
-    miniterm.join()
-    miniterm.close()
-
-    logger.info("")
-    logger.info(f"Reconnect with 'qtpy-datalogger connect --port {port}'")
-
-
 def discover_and_select_qtpy(
     group_id: str,
     transport: ConnectionTransport = ConnectionTransport.AutoSelect,
@@ -351,30 +292,6 @@ def discover_and_select_qtpy(
 
     logger.info(f"{selected_reason} '{selected_device.device_description}' as {transport_message}")
     return (selected_device, selected_transport)
-
-
-def _query_ports_from_serial() -> dict[str, dict[DetailKey, str]]:
-    """
-    Scan the system for serial ports and return a dictionary of information.
-
-    Returned entries, grouped by com_port
-    - com_port
-    - com_id
-    - serial_number
-    """
-    # Other approaches include WMI's Win32_SerialPort
-    from serial.tools.list_ports_windows import comports  # noqa: PLC0415 -- dynamic import at runtime for Windows
-
-    discovered_comports = {
-        comport.device: {
-            DetailKey.com_port: comport.device,
-            DetailKey.com_id: comport.hwid,
-            DetailKey.serial_number: comport.serial_number,
-        }
-        for comport in sorted(comports())
-    }
-    logger.debug(discovered_comports)
-    return discovered_comports
 
 
 def _query_volumes_from_wmi() -> dict[str, dict[DetailKey, str]]:

--- a/src/qtpy_datalogger/network.py
+++ b/src/qtpy_datalogger/network.py
@@ -276,9 +276,7 @@ class QTPyController:
         """Disconnect from the MQTT broker and return any unprocessed messages."""
         unprocessed_messages = []
         if not self.message_queue.empty():
-            logger.warning(
-                f"Leaving {self.message_queue.qsize()} MQTT messages unprocessed."
-            )
+            logger.warning(f"Leaving {self.message_queue.qsize()} MQTT messages unprocessed.")
             unprocessed_messages = self.clear_messages()
             for unprocessed_message in unprocessed_messages:
                 logger.debug(unprocessed_message._asdict())

--- a/src/qtpy_datalogger/uart.py
+++ b/src/qtpy_datalogger/uart.py
@@ -1,0 +1,147 @@
+"""Functions and classes for communicating with QT Py sensor nodes over serial ports."""
+
+import asyncio
+import contextlib
+import logging
+
+import serial
+from serial.tools import miniterm as mt
+
+from qtpy_datalogger.datatypes import DetailKey
+
+logger = logging.getLogger(__name__)
+
+
+def query_ports_from_serial() -> dict[str, dict[DetailKey, str]]:
+    """
+    Scan the system for serial ports and return a dictionary of information.
+
+    Returned entries, grouped by com_port
+    - com_port
+    - com_id
+    - serial_number
+    """
+    # Other approaches include WMI's Win32_SerialPort
+    from serial.tools.list_ports_windows import comports  # noqa: PLC0415 -- dynamic import at runtime for Windows
+
+    discovered_comports = {
+        comport.device: {
+            DetailKey.com_port: comport.device,
+            DetailKey.com_id: comport.hwid,
+            DetailKey.serial_number: comport.serial_number,
+        }
+        for comport in sorted(comports())
+    }
+    logger.debug(discovered_comports)
+    return discovered_comports
+
+
+def open_session_on_port(port: str) -> None:
+    """Open a terminal connection to the specified serial port."""
+    serial_options = _get_default_uart_options(port)
+    logger.debug(serial_options)
+    com_port = serial.serial_for_url(**serial_options)
+
+    if not hasattr(com_port, "cancel_read"):
+        # Enable timeout for alive flag polling if cancel_read is not available
+        com_port.timeout = 1
+
+    if isinstance(com_port, serial.Serial):
+        com_port.exclusive = True
+
+    com_port.open()
+
+    miniterm_options = {
+        "serial_instance": com_port,
+        "echo": False,
+        "eol": "crlf",
+        "filters": ["direct"],
+    }
+    logger.debug(miniterm_options)
+    miniterm = mt.Miniterm(**miniterm_options)
+
+    miniterm.exit_character = "\x1d"
+    miniterm.menu_character = "\x14"
+    miniterm.raw = False
+    miniterm.set_rx_encoding("UTF-8")
+    miniterm.set_tx_encoding("UTF-8")
+
+    quit_command = mt.key_description(miniterm.exit_character)
+    help_command = mt.key_description(miniterm.menu_character)
+    logger.info(
+        f"---   Miniterm on {miniterm.serial.name}   Opts: {miniterm.serial.baudrate},{miniterm.serial.bytesize},{miniterm.serial.parity},{miniterm.serial.stopbits}    ---"
+    )
+    logger.info(f"---   Quit: {quit_command}        Help: {help_command} then H   ---")
+
+    miniterm.start()
+    with contextlib.suppress(KeyboardInterrupt):
+        miniterm.join(True)
+    miniterm.join()
+    miniterm.close()
+
+    logger.info("")
+    logger.info(f"Reconnect with 'qtpy-datalogger connect --port {port}'")
+
+
+def open_uart(port: str) -> serial.Serial:
+    """Open a UART connection to the specified serial port and return the opened UART."""
+    if port == "COM1":
+        logger.error(f"Opening '{port}' is not supported.")
+        raise ValueError
+
+    serial_options = _get_default_uart_options(port)
+    serial_options.update(
+        {
+            "timeout": 0,
+            "write_timeout": 0,
+        }
+    )
+    logger.debug(serial_options)
+    com_port = serial.serial_for_url(**serial_options)
+
+    if isinstance(com_port, serial.Serial):
+        com_port.exclusive = True
+
+    com_port.open()
+    com_port.reset_input_buffer()
+    com_port.reset_output_buffer()
+    return com_port
+
+
+def send_message_as_line(message: str, com_port: serial.Serial) -> None:
+    """Append a newline to the message, encode it, and write it to the UART."""
+    with_newline = f"{message.strip()}\n"
+    uart_bytes = with_newline.encode()
+    logger.debug(uart_bytes)
+    com_port.write(uart_bytes)
+    com_port.flush()
+
+
+async def wait_until_line_received(com_port: serial.Serial) -> str:
+    """Cooperatively read bytes from the UART until receiving a newline. Decode the bytes and return the response."""
+    input_buffer = bytearray()
+    end_of_response = b"\r\n"
+    while not input_buffer.endswith(end_of_response):
+        if not com_port.in_waiting:
+            await asyncio.sleep(1e-3)
+            continue
+        new_bytes = com_port.read(1024)
+        if new_bytes:
+            logger.debug(new_bytes)
+            input_buffer.extend(new_bytes)
+    response = input_buffer.decode().splitlines()[-1]
+    return response
+
+
+def _get_default_uart_options(port: str) -> dict:
+    """Get the default serial port options for QT Py devices."""
+    return {
+        "url": port,
+        "baudrate": 115200,
+        "bytesize": 8,
+        "parity": "N",
+        "stopbits": 1,
+        "rtscts": False,
+        "xonxoff": False,
+        "do_not_open": True,
+    }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -4,7 +4,7 @@ import click
 import pytest
 import serial
 
-from qtpy_datalogger import discovery, network
+from qtpy_datalogger import discovery, network, uart
 from qtpy_datalogger.datatypes import Default, DetailKey, ExitCode
 from qtpy_datalogger.sensor_node.snsr.node import classes as node_classes
 
@@ -451,7 +451,7 @@ def test_windows_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
             },
         }
 
-    monkeypatch.setattr(discovery, "_query_ports_from_serial", override_ports_from_serial)
+    monkeypatch.setattr(uart, "query_ports_from_serial", override_ports_from_serial)
     monkeypatch.setattr(discovery, "_query_volumes_from_wmi", override_volumes_from_wmi)
     monkeypatch.setattr(network, "query_nodes_from_mqtt", override_nodes_from_mqtt)
 


### PR DESCRIPTION
## Summary

This PR moves the UART functions from the `discovery` submodule into a new submodule named `uart`.

It also adds new functions for asynchronously communicating with sensor nodes from apps.

Finally, it updates the CI Action to run `ruff format` and address lingering errors.

## Design

**`discovery`**

- Move **`open_session_on_port()`**
- Move **`query_ports_from_serial()`**

**`uart`**

- Add **`open_uart()`** -- Open a UART connection to the specified serial port and return the opened UART
- Add **`send_message_as_line()`** -- Append a newline to the message, encode it, and write it to the UART
- Add **`wait_until_line_received()`** -- Cooperatively read bytes from the UART until receiving a newline. Decode the bytes and return the response

## Screenshots or logs

### `demo.py`

```python
import asyncio

from qtpy_datalogger import uart
from qtpy_datalogger.datatypes import DetailKey
from qtpy_datalogger.sensor_node.snsr.node.classes import ActionInformation


async def main():
    action = ActionInformation(
        command="custom",
        parameters={"input": "qtpycmd stats"},
        message_id="anyid",
    )

    uarts = uart.query_ports_from_serial()
    qtpy_port = ""
    for candidate in uarts.values():
        qtpy_port = candidate[DetailKey.com_port]
        if qtpy_port != "COM1":
            break
    if qtpy_port in ["COM1", ""]:
        return
    qtpy_uart = uart.open_uart(qtpy_port)
    uart.send_message_as_line(action.parameters["input"], qtpy_uart)
    try:
        result = await uart.wait_until_line_received(qtpy_uart)
        print(f"{qtpy_uart.name} responded with {result}")
    except TimeoutError:
        print("no responses")
    qtpy_uart.close()


asyncio.run(main())
```

**`uv run python demo.py`**
```
COM4 responded with 59.453 kB used | 1953.547 kB free | 7707.95 s uptime
```

## Testing

- See demo above

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
