### PR TITLE
equip: Do not scan the network for MQTT nodes

### DIFF
--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -20,7 +20,7 @@ import toml
 
 from qtpy_datalogger import discovery
 
-from .datatypes import ConnectionTransport, Default, ExitCode, Links, SnsrNotice, SnsrPath
+from .datatypes import ConnectionTransport, ExitCode, Links, SnsrNotice, SnsrPath
 
 logger = logging.getLogger(__name__)
 
@@ -111,8 +111,8 @@ def handle_equip(behavior: Behavior, root: pathlib.Path | None, secrets: str) ->
 
     if not root:
         qtpy_device, communication_transport = discovery.discover_and_select_qtpy(
-            Default.MqttGroup,
-            ConnectionTransport.UART_Serial,
+            group_id="",
+            transport=ConnectionTransport.UART_Serial,
         )
         if not qtpy_device:
             logger.error("No QT Py devices found!")


### PR DESCRIPTION
## Summary

This PR changes the `equip` command to skip scanning the network for MQTT nodes because QT Py devices cannot change their _own_ files by default and so cannot update themselves by receiving files over the network.

The side effect is much faster execution because discovering USB-connected nodes does not need to wait for a node to respond to an identify message.

## Design

Use an empty string for the MQTT group to skip searching the network.

## Screenshots or logs

Compare the execution time of **`qtpy-datalogger equip --compare`** before and after the change.
- Before: **6.15s**
- After: **0.79s**

### Before

**`measure-command {qtpy-datalogger equip --compare}`**

```pwsh
...
INFO     Comparing sensor_node device with this package
INFO         Trait        Device (newer)                              Self        
INFO      ===========  ------------------------------------------  ----------------------
INFO       Version      1.0.10rc0.dev0                              1.0.10rc0.dev0
INFO       Timestamp    2026.06.20  13:44:30                        2026.06.14  15:10:22
INFO       CircuitPy    9.2.1                                       (PC host)
INFO       Board ID     adafruit_qtpy_esp32s3_nopsram               (PC host)
INFO       Location     D:\                                         (builtin)
INFO     
INFO     Newer files
INFO       * qtpy_sensor_node.md
INFO       * snsr\apps\__init__.py
INFO       * snsr\core.py
INFO       * snsr\handlers.py
INFO       * snsr\node\__init__.py
INFO       * snsr\node\mqtt.py
INFO       * snsr\pysh\diagnostics.py
INFO       * snsr\pysh\py_shell.py
INFO       * snsr\rxtx.py
INFO       * snsr\settings.py

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 6
Milliseconds      : 145
Ticks             : 61457579
TotalDays         : 7.11314571759259E-05
TotalHours        : 0.00170715497222222
TotalMinutes      : 0.102429298333333
TotalSeconds      : 6.1457579
TotalMilliseconds : 6145.7579
```

### After

**`measure-command {qtpy-datalogger equip --compare}`**

```pwsh
...
INFO     Comparing sensor_node device with this package
INFO         Trait        Device                                      Self (newer)
INFO      ===========  ------------------------------------------  ----------------------
INFO       Version      1.0.10rc0.dev0                              1.0.10rc0.dev0
INFO       Timestamp    2026.06.20  13:44:30                        2026.06.20  17:17:27
INFO       CircuitPy    9.2.1                                       (PC host)
INFO       Board ID     adafruit_qtpy_esp32s3_nopsram               (PC host)
INFO       Location     D:\                                         (builtin)
INFO     
INFO     Newer files
INFO       * code.py
INFO       * snsr\apps\echo.py
INFO       * snsr\apps\qtpycmd.py
INFO       * snsr\node\classes.py

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 790
Ticks             : 7905476
TotalDays         : 9.14985648148148E-06
TotalHours        : 0.000219596555555556
TotalMinutes      : 0.0131757933333333
TotalSeconds      : 0.7905476
TotalMilliseconds : 790.5476
```

## Testing

- See the comparison above
- PR checks

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
