### PR TITLE
Host API: Fix call sequence for on_showing()

### DIFF
--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -227,7 +227,7 @@ class ScannerApp(guikit.AsyncWindow):
 
         self.clear_results()
 
-    def on_show(self) -> None:
+    async def on_showing(self) -> None:
         """Initialize window before entering main loop."""
         self.group_input.focus()
 

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -234,9 +234,9 @@ class AsyncWindow:
 
     async def show(self) -> None:
         """Show the window and cooperatively run with asyncio."""
-        await self.on_showing()
         self.root_window.deiconify()
         self.root_window.wait_visibility()
+        await self.on_showing()
         self.root_window.update()
 
         while self.should_run_loop:


### PR DESCRIPTION
## Summary

This PR correctly sequences the call to **`AsyncWindow.on_showing()`** when opening an app so that it can take effect.

## Design

The call to **`on_showing()`** must happen _after_ the window has been presented and rendered, otherwise GUI elements have no visuals to configure and customize.

## Screenshots or logs

_After_ fixing the override name but _before_ fixing the call sequence, when the Scanner app opened, the _Group name_ field had no focus, showing that Scanner's override for **`on_showing()`** had no effect.

Fixing the call sequence causes the _Group name_ field to have focus.

### Before

<img width="639" height="380" alt="image" src="https://github.com/user-attachments/assets/f2ad20be-a76c-4676-ae45-5ec03366e6f3" />

## After

<img width="641" height="384" alt="image" src="https://github.com/user-attachments/assets/221db09d-41d8-4dee-983a-72c0988db506" />

## Testing

- See demo above

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
