### PR TITLE
Stack API: Add factory methods for custom commands and responses

### DIFF
--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -7,7 +7,7 @@ from traceback import print_exception
 
 from snsr.core import get_app, read_one_uart_line
 from snsr.handlers import can_handle_message, get_sender_information
-from snsr.node.classes import ActionPayload, create_custom_with_input
+from snsr.node.classes import ActionPayload
 from snsr.node.mqtt import get_broadcast_topic, get_command_topic, get_descriptor_topic
 from snsr.rxtx import connect_and_subscribe, create_mqtt_client, unsubscribe_and_disconnect
 from snsr.settings import settings
@@ -40,7 +40,7 @@ def main_loop() -> str:
             action_payload = can_handle_message(uart_input)
             made_custom = False
             if not action_payload:
-                action_payload = create_custom_with_input(uart_input.strip())
+                action_payload = ActionPayload.create_custom_with_input(uart_input.strip())
                 made_custom = True
 
             app = get_app(action_payload.action)

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/echo.py
@@ -10,14 +10,7 @@ class EchoApp(SnsrApp):
     def handle_message(self) -> ActionInformation:
         """Handle a received action from the controlling host."""
         echo = self.action.parameters.get("input", self.action.command)
-        response_action = ActionInformation(
-            command=self.action.command,
-            parameters={
-                "output": f"received: {echo}",
-                "complete": True,
-            },
-            message_id=self.action.message_id,
-        )
+        response_action = ActionInformation.create_custom_response(self.action, f"received: {echo}")
         return response_action
 
     def did_handle_message(self) -> None:

--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -36,23 +36,16 @@ def create_app(received_action: ActionInformation) -> SnsrApp:
     return QtpyCmdApp(received_action)
 
 
-def build_response(received_action: ActionInformation, message: object) -> ActionInformation:
+def build_response(received_action: ActionInformation, message: str) -> ActionInformation:
     """Create an action response with the specified message."""
-    response_action = ActionInformation(
-        command=received_action.parameters["input"],
-        parameters={
-            "output": message,
-            "complete": True,
-        },
-        message_id=received_action.message_id,
-    )
+    response_action = ActionInformation.create_custom_response(received_action, message)
     return response_action
 
 
 def handle_get_apps(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
     """Handle the 'qtpycmd get_apps' action."""
     apps = settings.app_catalog
-    return build_response(received_action, sorted(apps))
+    return build_response(received_action, ",".join(sorted(apps)))
 
 
 def handle_get_stats(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:

--- a/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
@@ -343,6 +343,18 @@ class ActionPayload:
         sender_information = SenderInformation.from_dict(dictionary["sender"])
         return ActionPayload(action_information, sender_information)
 
+    @staticmethod
+    def create_custom_with_input(input_string: str) -> "ActionPayload":
+        """Return an ActionPayload for a custom command with the specified input."""
+        payload = ActionPayload(
+            action=ActionInformation.create_custom_command(
+                custom_input=input_string,
+                custom_id="create_custom_with_input",
+            ),
+            sender=SenderInformation.create_empty(),
+        )
+        return payload
+
     def as_dict(self) -> dict:
         """Return a dictionary representation."""
         return self.information
@@ -356,26 +368,3 @@ class ActionPayload:
     def sender(self) -> SenderInformation:
         """The sender of the payload."""
         return SenderInformation.from_dict(self.information["sender"])
-
-
-def create_custom_with_input(input_string: str) -> ActionPayload:
-    """Return an ActionPayload for a custom command with the specified input."""
-    payload = ActionPayload(
-        action=ActionInformation(
-            command="custom",
-            parameters={
-                "input": input_string,
-            },
-            message_id="create_custom_with_input",
-        ),
-        sender=SenderInformation(
-            descriptor_topic="unused",
-            sent_at="unused",
-            status=StatusInformation(
-                used_memory="unused",
-                free_memory="unused",
-                cpu_temperature="unused",
-            ),
-        ),
-    )
-    return payload

--- a/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/node/classes.py
@@ -281,6 +281,27 @@ class ActionInformation:
         """Return a new ActionInformation from the specified dictionary."""
         return ActionInformation(**dictionary)
 
+    @staticmethod
+    def create_custom_command(custom_input: str, custom_id: str | None = None) -> "ActionInformation":
+        """Return a new ActionInformation that represents a custom command."""
+        custom_id = custom_id or "custom-action"
+        return ActionInformation("custom", {"input": custom_input}, custom_id)
+
+    @staticmethod
+    def create_custom_response(
+        custom_action: "ActionInformation", custom_output: str, complete: bool = True
+    ) -> "ActionInformation":
+        """Return a new ActionInformation that represents a response to a custom command."""
+        response_action = ActionInformation(
+            command=custom_action.command,
+            parameters={
+                "output": custom_output,
+                "complete": complete,
+            },
+            message_id=custom_action.message_id,
+        )
+        return response_action
+
     def as_dict(self) -> dict:
         """Return a dictionary representation."""
         return self.information


### PR DESCRIPTION
## Summary

This PR adds factory methods to the shared classes in **`snsr.node.classes`** so that both the host and the nodes can send and receive custom commands in a uniform way.

The built-in `echo` and `qtpycmd` node-side apps use the `ActionInformation` class to respond to commands received from the host. The structure of the `ActionInformation` instances mimic standard-input and standard-output.

### Custom command structure

```json
{
  "command": "custom",
  "parameters": {
    "input": COMMAND_INPUT_STRING
  },
  "message_id": ANY
}
```

### Custom response structure

```json
{
  "command": "custom",
  "parameters": {
    "output": COMMAND_OUTPUT_STRING,
    "complete": TRUE | FALSE
  },
  "message_id": MATCHES_INPUT
}
```

## Design

Update the node-side apps to use the new factory methods.

**`classes.py`**
- Add new static factory methods to `ActionInformation`
  - **`create_custom_command()`**
  - **`create_custom_response()`**
- Make **`create_custom_with_input()`** a static method on `ActionPayload` and update it to use the factory methods
  - `ActionInformation.create_custom_command()`
  - `SenderInformation.create_empty()`

## Screenshots or logs

See testing below.

## Testing

The call to `qtpycmd get_apps` still succeeds.

**`qtpy-datalogger connect`**
```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group 'zone1'
INFO     Identifying QT Py devices
INFO     QT Py device 'Adafruit QT Py ESP32-S3 no PSRAM' has UART and MQTT available, select a connection transport to continue
  1:  MQTT  (WiFi)
  2:  UART  (serial)
Enter a transport number (1, 2): 1
INFO     User-selected 'Adafruit QT Py ESP32-S3 no PSRAM' as MQTT node 'node-42cea4d12c8b-0' on '192.168.0.12'
Use any of 'exit' or 'quit' to exit.
node-42cea4d12c8b-0 > qtpycmd get_apps
Received '['echo', 'qtpycmd']' from node with 76.375 kB used, 61.688 kB remaining, at temperature 56.4 degC
node-42cea4d12c8b-0 > exit
```

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
