### PR TITLE
Node API: qtpycmd: Fix typo in get_apps result

### DIFF
--- a/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/apps/qtpycmd.py
@@ -45,7 +45,7 @@ def build_response(received_action: ActionInformation, message: str) -> ActionIn
 def handle_get_apps(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:
     """Handle the 'qtpycmd get_apps' action."""
     apps = settings.app_catalog
-    return build_response(received_action, ",".join(sorted(apps)))
+    return build_response(received_action, f"[{', '.join(sorted(apps))}]")
 
 
 def handle_get_stats(received_action: ActionInformation, command_args: list[str]) -> ActionInformation:


### PR DESCRIPTION
## Summary

This PR restores the output from `qtpycmd get_apps` to use json-like representation.

## Design

Update the handler to include `[ ... ]` bookends and separate values with `, `.

## Screenshots or logs

- See testing below

## Testing

Using a UART connection.

### Before

```
qtpycmd get_apps
echo,qtpycmd
```

### After

```
qtpycmd get_apps
[echo, qtpycmd]
```

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
