### PR TITLE
Node API: Allow UART only operation

### DIFF
--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -5,6 +5,7 @@ from json import dumps
 from time import monotonic, sleep
 from traceback import print_exception
 
+from adafruit_minimqtt.adafruit_minimqtt import MMQTTException
 from snsr.core import get_app, read_one_uart_line
 from snsr.handlers import can_handle_message, get_sender_information
 from snsr.node.classes import ActionPayload
@@ -19,18 +20,21 @@ mqtt_topics = [
 ]
 
 
-def main_loop() -> str:
+def main_loop(skip_mqtt: bool) -> str:
     """Run the main node loop."""
-    settings.connect_to_wifi()
-    mqtt_client = create_mqtt_client(settings.node_group, settings.mqtt_client_id)
-    connect_and_subscribe(mqtt_client, mqtt_topics)
+    mqtt_client = None
+    if not skip_mqtt:
+        settings.connect_to_wifi()
+        mqtt_client = create_mqtt_client(settings.node_group, settings.mqtt_client_id)
+        connect_and_subscribe(mqtt_client, mqtt_topics)
 
     uart_input = ""
     while uart_input.lower() not in ["exit", "quit"]:
         uart_connected = settings.uart_connected
-        did_receive = mqtt_client.loop(timeout=1.0)  # Smallest supported timeout
-        if not (did_receive or uart_connected):
-            sleep(4)  # Conserve battery by not constantly polling the network
+        if mqtt_client:
+            did_receive = mqtt_client.loop(timeout=1.0)  # Smallest supported timeout
+            if not (did_receive or uart_connected):
+                sleep(4)  # Conserve battery by not constantly polling the network
 
         if uart_connected:
             sleep(0.2)
@@ -46,7 +50,6 @@ def main_loop() -> str:
             app = get_app(action_payload.action)
             result = app.handle_message()
 
-            response = ""
             if made_custom:
                 response = result.parameters["output"]
             else:
@@ -58,7 +61,8 @@ def main_loop() -> str:
 
             app.did_handle_message()
 
-    unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
+    if mqtt_client:
+        unsubscribe_and_disconnect(mqtt_client, mqtt_topics)
     return uart_input
 
 
@@ -67,9 +71,13 @@ error_count = 0
 error_limit = 3
 while True:
     try:
-        result = main_loop()
+        mqtt_failed = most_recent_error is MMQTTException
+        skip_mqtt = settings.uart_connected and mqtt_failed
+        if skip_mqtt:
+            print("[SNSR]  Disabling MQTT: broker is unreachable")
+        result = main_loop(skip_mqtt)
         if result.lower() in ["exit", "quit"]:
-            print("Exiting to REPL...")
+            print("[SNSR]  Exiting to REPL...")
             break
     except Exception as e:
         try:
@@ -77,7 +85,7 @@ while True:
         except AttributeError:
             pass
         print()
-        print(f"Encountered {type(e)} {e.args}")
+        print(f"[SNSR]  Encountered {type(e).__name__}")
         print_exception(e)
         collect()
         if type(e) is most_recent_error:
@@ -87,5 +95,5 @@ while True:
         else:
             most_recent_error = type(e)
             error_count = 0
-        print("Trying again...")
+        print("[SNSR]  Trying again...")
         continue

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -71,10 +71,12 @@ error_count = 0
 error_limit = 3
 while True:
     try:
+        wifi_failed = most_recent_error is ConnectionError
         mqtt_failed = most_recent_error is MMQTTException
-        skip_mqtt = settings.uart_connected and mqtt_failed
+        skip_mqtt = settings.uart_connected and (wifi_failed or mqtt_failed)
         if skip_mqtt:
-            print("[SNSR]  Disabling MQTT: broker is unreachable")
+            reason = "incorrect WiFi credentials" if wifi_failed else "broker is unreachable"
+            print(f"[SNSR]  Disabling MQTT: {reason}")
         result = main_loop(skip_mqtt)
         if result.lower() in ["exit", "quit"]:
             print("[SNSR]  Exiting to REPL...")


### PR DESCRIPTION
## Summary

This PR hardens the **`code.py`** main loop on the sensor node so that it continues running when WiFi or MQTT are unavailable as long as the node has a UART connection.

## Design

- Detect WiFi and MQTT errors
- Skip connecting to MQTT when UART is available

## Screenshots or logs

Using a UART connection with incorrect `settings.toml` values

```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group 'zone1'
INFO     Identifying QT Py devices
INFO     Auto-selected 'Adafruit QT Py ESP32-S3 no PSRAM' as port 'COM18' on 'D:\'
INFO     ---   Miniterm on COM18   Opts: 115200,8,N,1    ---
INFO     ---   Quit: Ctrl+]        Help: Ctrl+T then H   ---
exit
received: exit
[SNSR]  Exiting to REPL...

Code done running.

Adafruit CircuitPython 9.2.1 on 2024-11-20; Adafruit QT Py ESP32-S3 no psram with ESP32S3
>>> 
>>> 
>>> 
soft reboot

Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:

[SNSR]  Encountered MMQTTException
Traceback (most recent call last):
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 448, in connect
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 545, in _connect
  File "adafruit_connection_manager.py", line 331, in get_socket
  File "adafruit_connection_manager.py", line 248, in _get_connected_socket
OSError: [Errno 116] ETIMEDOUT

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "code.py", line 80, in <module>
  File "code.py", line 29, in main_loop
  File "snsr/rxtx.py", line 70, in connect_and_subscribe
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 482, in connect
MMQTTException: ('Repeated connect failures', None)
[SNSR]  Trying again...
[SNSR]  Disabling MQTT: broker is unreachable
qtpycmd read A0
[9910.4] (raw ADC codes, 15 samples averaged)
```

## Testing

See above for demo.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
