### PR TITLE
Examples: Ensure analog_plotter exits even when nodes stop responding

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -19,18 +19,18 @@ A custom host-side app that plots analog data using the built-in sensor node app
 
 ![Screenshot of Analog Plotter demo app](gallery/ex-analog-plotter.png)
 
-1. Copy the app's source file `analog_plotter.py` to your `qtpy-preview` folder
+1. **Copy** the app's source file `analog_plotter.py` to your `qtpy-preview` folder
     - [View] it in your browser
     - [Save-As] to download it directly
-1. Run it with
+1. **Run** it with
     ```pwsh title="PowerShell"
     python analog_plotter.py
     ```
-1. Edit the [variables at the top] of `get_and_plot_data()` to exercise the features
+1. **Edit** the [variables at the top] of `get_and_plot_data()` to exercise the features
     ```python title="get_and_plot_data()"
       # Customize
       use_uart = True
-      use_mqtt = True
+      use_mqtt = False
       minimum_mqtt_node_count = 1
       channel_cmd_string = "A0 A3"
       mqtt_group = datatypes.Default.MqttGroup

--- a/examples/analog_plotter/analog_plotter.py
+++ b/examples/analog_plotter/analog_plotter.py
@@ -239,7 +239,7 @@ class AnalogPlotter(guikit.AsyncWindow):
             self.mqtt_task = asyncio.create_task(do_mqtt_collect(self.mqtt_controller))
 
         # Many loops later...
-        if self.mqtt_task and self.mqtt_task.done():
+        if self.mqtt_controller and self.mqtt_task and self.mqtt_task.done():
             mqtt_node_voltages = self.mqtt_task.result()
             for node_name, voltages in mqtt_node_voltages.items():
                 logger.info(f"{time_coordinate:.5f}  ::MQTT::  received  {node_name}")

--- a/examples/analog_plotter/analog_plotter.py
+++ b/examples/analog_plotter/analog_plotter.py
@@ -309,8 +309,13 @@ class AnalogPlotter(guikit.AsyncWindow):
             if self.mqtt_task:
                 logger.info("Clearing retained MQTT message")
                 self.mqtt_controller.clear_retained_group_action()
-                _ = await self.mqtt_task
-                self.mqtt_task = None
+                try:
+                    async with asyncio.timeout(5.0):
+                        _ = await self.mqtt_task
+                except TimeoutError:
+                    pass
+                finally:
+                    self.mqtt_task = None
             logger.info("Closing MQTT connection")
             _ = self.mqtt_controller.clear_messages()
             await self.mqtt_controller.disconnect()

--- a/examples/analog_plotter/analog_plotter.py
+++ b/examples/analog_plotter/analog_plotter.py
@@ -160,7 +160,7 @@ class AnalogPlotter(guikit.AsyncWindow):
 
         # Customize
         use_uart = True
-        use_mqtt = True
+        use_mqtt = False
         minimum_mqtt_node_count = 1
         channel_cmd_string = "A0 A3"
         mqtt_group = datatypes.Default.MqttGroup


### PR DESCRIPTION
## Summary

This PR ensures that the **`analog_plotter`** example always exits, even when nodes go offline and stop responding.

## Design

Use `async with aysncio.timeout(...)` to cancel the MQTT task if it doesn't complete in time.

## Screenshots or logs

Using a node with incorrect MQTT settings but with a UART connection, the example begins waiting for 1 node to respond via MQTT. The node cannot respond via MQTT because it is offline, which keeps its infinite-wait MQTT task active, but the example exits cleanly anyway because the cleanup code cancels the task when the timeout expires.

**`uv run python .\examples\analog_plotter\analog_plotter.py`**
```diff
  INFO     Discovering serial ports
  INFO     Scanning the network for sensor_node devices in group ''
  INFO     Discovering disk volumes
  INFO     Identifying QT Py devices
- INFO     Waiting for 1 nodes to respond via MQTT
  INFO     0.63095  ==UART==  received  COM18
  INFO     0.84752  ==UART==  received  COM18
  INFO     1.09524  ==UART==  received  COM18
  INFO     1.34370  ==UART==  received  COM18
  INFO     1.57689  ==UART==  received  COM18
  INFO     1.83816  ==UART==  received  COM18
  INFO     2.07111  ==UART==  received  COM18
  INFO     2.31930  ==UART==  received  COM18
  INFO     2.56705  ==UART==  received  COM18
  INFO     2.81552  ==UART==  received  COM18
  INFO     3.06358  ==UART==  received  COM18
  INFO     Clearing active UART message
  INFO     Closing UART connection
  INFO     Clearing retained MQTT message
  INFO     Closing MQTT connection
```

## Testing

See demo above.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
