### PR TITLE
Bugs: Remove on-boarding hiccups

### DIFF
--- a/docs/eng/usage/guide.md
+++ b/docs/eng/usage/guide.md
@@ -31,10 +31,5 @@ If you want to add this package to your own project and use it in your code, add
 Then import the package like any other in your source code.
 
 ```py title="my_program.py"
-from qtpy_datalogger.network import QTPyController
+from qtpy_datalogger import discovery, snsrkit
 ```
-
-See the summary workflows below for recommended steps when working on
-
-- [Host](../intro/workflows/#pc-dev-loop) code
-- [Node](../intro/workflows/#qt-py-dev-loop) code

--- a/src/qtpy_datalogger/__init__.py
+++ b/src/qtpy_datalogger/__init__.py
@@ -1,1 +1,6 @@
 """qtpy_datalogger package."""
+
+import warnings
+
+# Suppress tjguk/wmi #32
+warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence.*")

--- a/src/qtpy_datalogger/equip.py
+++ b/src/qtpy_datalogger/equip.py
@@ -435,6 +435,7 @@ def _equip_snsr_node(behavior: Behavior, comparison_information: dict[str, SnsrN
         return_code = result.returncode
 
     if return_code == ExitCode.Success:
+        device_main_folder.joinpath("code.py").touch()  # Restart the node
         logger.info("Installation complete")
     else:
         logger.error(f"circup exited with code '{return_code}'")

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -55,7 +55,7 @@ class Settings:
         """Initialize the readonly settings from the environment variables."""
         from os import getenv
 
-        self._wifi_ssid = getenv("CIRCUITPY_WIFI_SSID", "")
+        self._wifi_ssid = getenv("CIRCUITPY_WIFI_SSID", "qtpy-no-wifi-ssid")
         self._wifi_password = getenv("CIRCUITPY_WIFI_PASSWORD", "")
         self._mqtt_broker = getenv("QTPY_BROKER_IP_ADDRESS", "")
         self._node_group = getenv("QTPY_NODE_GROUP", "zone1")


### PR DESCRIPTION
## Summary

This PR makes a few improvements to the first-time setup experience
- Reboot the node after equipping it
  - Otherwise it tries to run while circup is still executing, and so the node fails to import the still-incoming mpy modules and exits the main loop
- Use a default value for the WiFi SSID
  - Otherwise the node receives a ValueError for an empty SSID, and that error is too broad to accept when disabling MQTT
- Suppress https://github.com/tjguk/wmi/issues/32
- Revise wording for usage guide

## Design

- Update the files as necessary

## Screenshots or logs

_None_

## Testing

I followed the [Get started](https://downtothewire.io/qtpy-datalogger/get-started/) page, resetting the virtual environment each time, until it succeeded without intervention.

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
