### PR TITLE
Node API: Fix USB-only connectivity

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -27,6 +27,8 @@ A custom host-side app that plots analog data using the built-in sensor node app
     python analog_plotter.py
     ```
 1. **Edit** the [variables at the top] of `get_and_plot_data()` to exercise the features
+    - Note that this example only enables UART communication to start
+    - If you setup [MQTT](eng/intro/mqtt/) to use WiFi, change **`use_mqtt`** to **`True`**
     ```python title="get_and_plot_data()"
       # Customize
       use_uart = True

--- a/src/qtpy_datalogger/sensor_node/code.py
+++ b/src/qtpy_datalogger/sensor_node/code.py
@@ -73,7 +73,7 @@ while True:
     try:
         wifi_failed = most_recent_error is ConnectionError
         mqtt_failed = most_recent_error is MMQTTException
-        skip_mqtt = settings.uart_connected and (wifi_failed or mqtt_failed)
+        skip_mqtt = settings.usb_connected and (wifi_failed or mqtt_failed)
         if skip_mqtt:
             reason = "incorrect WiFi credentials" if wifi_failed else "broker is unreachable"
             print(f"[SNSR]  Disabling MQTT: {reason}")

--- a/src/qtpy_datalogger/sensor_node/snsr/settings.py
+++ b/src/qtpy_datalogger/sensor_node/snsr/settings.py
@@ -132,6 +132,11 @@ class Settings:
         return monotonic() - settings.boot_time
 
     @property
+    def usb_connected(self) -> bool:
+        """Return true if the sensor_node has a USB connection."""
+        return runtime.usb_connected
+
+    @property
     def uart_connected(self) -> bool:
         """Return true if the sensor_node has an open UART connection."""
         return runtime.usb_connected and runtime.serial_connected


### PR DESCRIPTION
## Summary

This PR fixes a node-side misbehavior that causes the node to exit the root loop when connected via USB.

If the node had an active UART session, then it would remain running.

## Design

- Add a new system state property to the `Settings` singleton named **`usb_connected`**
- Allow skipping MQTT setup when USB is connected without a UART session

## Screenshots or logs

_None_

## Testing

Workbench testing
1. Reset the preview virtual environment
2. Reset a node to empty
3. Use `equip`
4. Observe the NeoPixel for 15 seconds
   - ❌ Before: double-blink red
   - ✅ After: no blinking
5. Run the `analog_plotter` example
6. Configure MQTT
7. Switch the node to external power
8. Run the `analog_plotter` example with MQTT enabled

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] Documentation updated
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
