### PR TITLE
Host API: Detect CircuitPython10 devices

### DIFF
--- a/src/qtpy_datalogger/discovery.py
+++ b/src/qtpy_datalogger/discovery.py
@@ -169,11 +169,18 @@ def _process_query_results(
     qtpy_devices: dict[str, QTPyDevice] = {}
     for drive_info in discovered_disk_volumes.values():
         drive_serial_number = drive_info[DetailKey.serial_number]
+        short_drive_serial_number = drive_serial_number[:-1]
 
         for port_info in discovered_serial_ports.values():
             port_serial_number = port_info[DetailKey.serial_number]
+            if not port_serial_number:
+                continue
+            short_port_serial_number = port_serial_number[:-1]
 
-            if port_serial_number and port_serial_number == drive_serial_number:
+            # We compare with one character trimmed because CircuitPython 10.2.1 (and likely earlier)
+            # adds a second disk w/o any partitions which causes the serial numbers to differ at the end
+            # See https://github.com/adafruit/circuitpython/issues/11076 for details
+            if short_port_serial_number == short_drive_serial_number:
                 serial_number = port_serial_number.lower()
                 python_implementation, snsr_version, mqtt_group = _query_node_info_from_drive(
                     drive_info[DetailKey.drive_root]

--- a/src/qtpy_datalogger/uart.py
+++ b/src/qtpy_datalogger/uart.py
@@ -31,6 +31,7 @@ def query_ports_from_serial() -> dict[str, dict[DetailKey, str]]:
             DetailKey.serial_number: comport.serial_number,
         }
         for comport in sorted(comports())
+        if comport.device != "COM1"
     }
     logger.debug(discovered_comports)
     return discovered_comports


### PR DESCRIPTION
## Summary

This PR updates how the package detects CircuitPython devices so that it can also detect devices with **CircuitPython 10.x**.

## Design

**`uart.py`**

- Small optimization: skip collecting information about `COM1`

**`discovery.py`**

- Trim the last character from serial numbers when comparing them.
  - See https://github.com/adafruit/circuitpython/issues/11076 for details.

## Screenshots or logs

See testing below.

## Testing

**`> qtpy-datalogger connect --discover-only --group ''`**
```
INFO     Discovering serial ports
INFO     Discovering disk volumes
INFO     Scanning the network for sensor_node devices in group ''
INFO     Identifying QT Py devices

INFO           Port   Drive  QT Py device                         Node ID               Group ID    
INFO           -----  -----  -----------------------------------  --------------------  ------------
INFO       1:  COM18  F:\    Adafruit QT Py ESP32-S3 no PSRAM                           zone1
INFO       1:  COM4   E:\    Adafruit QT Py ESP32-S3 2MB PSRAM
```
✅ Detected two CircuitPython devices

---

**`> cat f:\boot_out.txt`**
```
Adafruit CircuitPython 9.2.1 on 2024-11-20; Adafruit QT Py ESP32-S3 no psram with ESP32S3
Board ID:adafruit_qtpy_esp32s3_nopsram
UID:42CEA4D12C8B
```
✅ Detected CircuitPython 9.2.1

---

**`> cat e:\boot_out.txt`**
```
Adafruit CircuitPython 10.2.1 on 2026-05-13; Adafruit QT Py ESP32-S3 4MB Flash 2MB PSRAM with ESP32S3
Board ID:adafruit_qtpy_esp32s3_4mbflash_2mbpsram
UID:4F21AFA56341
MAC:54:64:CB:3F:40:4F
```
✅ Detected CircuitPython 10.2.1

## Checklist

- [x] ~~Issues linked / labels applied~~
- [x] ~~Documentation updated~~
- [x] ~~Tests added / updated / removed~~
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
