### PR TITLE
Host API: Change to ttkbootstrap_icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           '3.11',
           '3.12',
           '3.13',
-          # '3.14',   In some way, tkfontawesome brings lxml 5.4 which is not available for Python 3.14
+          '3.14',
         ]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Custom ignores
+.python-version
 .ruff_cache/
 ignored/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pandas>=3.0.2",
     "psutil>=7.2.2",
     "pyserial>=3.5",
+    "tksvg>=0.7.4",
     "ttkbootstrap>=1.20.2",
     "ttkbootstrap-icons>=4.0.0",
     "ttkbootstrap-icons-fa>=1.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "pandas>=3.0.2",
     "psutil>=7.2.2",
     "pyserial>=3.5",
-    "tkfontawesome>=0.3.2",
     "ttkbootstrap>=1.20.2",
     "ttkbootstrap-icons>=4.0.0",
     "ttkbootstrap-icons-fa>=1.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "pyserial>=3.5",
     "tkfontawesome>=0.3.2",
     "ttkbootstrap>=1.20.2",
+    "ttkbootstrap-icons>=4.0.0",
     "wmi>=1.5.1",
 
     # sensor_node

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "tkfontawesome>=0.3.2",
     "ttkbootstrap>=1.20.2",
     "ttkbootstrap-icons>=4.0.0",
+    "ttkbootstrap-icons-fa>=1.0.2",
     "wmi>=1.5.1",
 
     # sensor_node

--- a/src/qtpy_datalogger/__init__.py
+++ b/src/qtpy_datalogger/__init__.py
@@ -3,4 +3,4 @@
 import warnings
 
 # Suppress tjguk/wmi #32
-warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence.*")
+warnings.filterwarnings("ignore", category=SyntaxWarning, message=".*invalid escape sequence.*")

--- a/src/qtpy_datalogger/apps/data_viewer.py
+++ b/src/qtpy_datalogger/apps/data_viewer.py
@@ -21,7 +21,6 @@ import numpy as np
 import pandas as pd
 import ttkbootstrap as ttk
 import ttkbootstrap.themes.standard as ttk_themes
-from tkfontawesome import icon_to_image
 from ttkbootstrap import constants as bootstyle
 
 from qtpy_datalogger import guikit, ttkbootstrap_matplotlib
@@ -156,7 +155,7 @@ class DataViewer(guikit.AsyncWindow):
         self.next_update_time = time.time()
         self.state = AppState(self.root_window)
 
-        app_icon = icon_to_image("chart-line", fill=app_icon_color, scale_to_height=256)
+        app_icon = guikit.image_from_icon("chart-line", fill=app_icon_color, scale_to_height=64)
         self.root_window.iconphoto(True, app_icon)
 
         figure_dpi = 112
@@ -409,7 +408,9 @@ class DataViewer(guikit.AsyncWindow):
     ) -> ttk.Button:
         """Create a ttk.Button using the specified text and FontAwesome icon_name."""
         text_spacing = 3 * " "
-        button_image = icon_to_image(icon_name, fill=guikit.hex_string_for_style(StyleKey.SelectFg), scale_to_height=24)
+        button_image = guikit.image_from_icon(
+            icon_name, fill=guikit.hex_string_for_style(StyleKey.SelectFg), scale_to_height=24
+        )
         self.svg_images[icon_name] = button_image
         button = ttk.Button(
             parent,

--- a/src/qtpy_datalogger/apps/scanner.py
+++ b/src/qtpy_datalogger/apps/scanner.py
@@ -13,7 +13,6 @@ import ttkbootstrap as ttk
 import ttkbootstrap.icons as ttk_icons
 import ttkbootstrap.widgets.scrolled as ttk_scrolled
 import ttkbootstrap.widgets.tableview as ttk_tableview
-from tkfontawesome import svg_to_image
 from ttkbootstrap import constants as bootstyle
 
 import qtpy_datalogger
@@ -91,7 +90,7 @@ class ScannerApp(guikit.AsyncWindow):
         package = importlib.resources.files(qtpy_datalogger)
         assets = package.joinpath("assets")
         telescope_data = assets.joinpath("telescope.svg").read_text()
-        icon = svg_to_image(telescope_data, fill="#07a000", scale_to_height=256)
+        icon = guikit.image_from_svg(telescope_data, fill="#07a000", scale_to_height=64)
         self.root_window.minsize(width=560, height=572)
         self.root_window.title(Constants.AppName)
         self.root_window.iconphoto(True, icon)
@@ -113,7 +112,9 @@ class ScannerApp(guikit.AsyncWindow):
         main.rowconfigure(5, weight=0)
 
         # Title
-        telescope_image = svg_to_image(telescope_data, fill=guikit.hex_string_for_style("fg"), scale_to_height=25)
+        telescope_image = guikit.image_from_svg(
+            telescope_data, fill=guikit.hex_string_for_style("fg"), scale_to_height=25
+        )
         self.svg_images["telescope"] = telescope_image
         title_font = font.Font(weight="bold", size=24)
         title_label = ttk.Label(

--- a/src/qtpy_datalogger/datatypes.py
+++ b/src/qtpy_datalogger/datatypes.py
@@ -24,6 +24,7 @@ class Links(enum.StrEnum):
     New_Bug = "https://github.com/wireddown/qtpy-datalogger/issues/new?template=bug-report.md"
     Board_Support_Matrix = "https://docs.circuitpython.org/en/stable/shared-bindings/support_matrix.html"
     MQTT_Walkthrough = "https://wireddown.github.io/qtpy-datalogger/eng/intro/mqtt/"
+    Help = "https://downtothewire.io/qtpy-datalogger/welcome/"
 
 
 class ExitCode(enum.IntEnum):

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -1115,7 +1115,7 @@ def get_first_in_range(upper_bound: float, selection: dict) -> Any:  # noqa ANN4
     return first_value_in_range
 
 
-def image_from_icon(name: str, fill: str | None = None, scale_to_width: int | None = None, scale_to_height: int | None = None, scale: float = 1) -> tk.PhotoImage:
+def image_from_icon(name: str, fill: str | None = None, scale_to_width: int | None = None, scale_to_height: int | None = None) -> tk.PhotoImage:
     """Look up a FontAwesome icon by name and return it as an PhotoImage object."""
     return icon_to_image(name, fill, scale_to_width, scale_to_height, scale)
 

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -23,8 +23,9 @@ import ttkbootstrap.icons as ttk_icons
 import ttkbootstrap.style as ttk_style
 import ttkbootstrap.themes.standard as ttk_themes
 import ttkbootstrap.tooltip as ttk_tooltip
-from tkfontawesome import icon_to_image
 from ttkbootstrap import constants as bootstyle
+from ttkbootstrap_icons import Icon
+from ttkbootstrap_icons.providers import BaseFontProvider
 
 from qtpy_datalogger import datatypes
 
@@ -493,7 +494,7 @@ class AboutDialog(AsyncDialog):
             command=functools.partial(webbrowser.open_new_tab, self.help_url),
         )
         help_button.grid(column=5, row=4, sticky=tk.W, pady=(18, 0))
-        self.source_icon = image_from_icon("github-alt", fill=button_text_color, scale_to_width=16)
+        self.source_icon = image_from_icon("github-alt-brands", fill=button_text_color, scale_to_width=16)
         source_button = ttk.Button(
             message_frame,
             compound=tk.LEFT,
@@ -854,6 +855,43 @@ class ThemeChanger:
         owner.winfo_toplevel().event_generate(ThemeChanger.Event.BootstrapThemeChanged)
 
 
+class CustomFontAwesomeIcon(Icon):
+    """A custom image renderer for FontAwesome icons."""
+
+    def __init__(self, name: str, size: int = 24, color: str = "black") -> None:
+        """
+        Create an image from a FontAwesome icon using the specified name, size, and fill color.
+
+        'name' is taken from the solid subset unless it ends with -regular or -brands.
+        """
+        y_adjust = 0.125  # MOVES the rendered font text DOWN by this fraction of the size
+        pad_factor = 0.0  # SHRINKS the render area by this fraction of the size on each side
+        padded_size = round(1 * size)
+        custom_provider = BaseFontProvider(
+            name="fontawesome",
+            display_name="Font Awesome 6 (Free)",
+            package="ttkbootstrap_icons_fa",
+            homepage="https://fontawesome.com/v6/icons",
+            license_url="https://fontawesome.com/license",
+            icon_version="6.7.2",
+            default_style="solid",
+            styles={
+                "solid": {"filename": "fonts/fa-solid-900.ttf"},
+                "regular": {"filename": "fonts/fa-regular-400.ttf"},
+                "brands": {"filename": "fonts/fa-brands-400.ttf"},
+            },
+            pad_factor=pad_factor,
+            y_bias=y_adjust,
+            scale_to_fit=True,
+        )
+        auto_style = None
+        resolved_style = custom_provider.resolve_icon_style(name, auto_style)
+        # The package caches the provider by its name and style
+        Icon.initialize_with_provider(custom_provider, resolved_style)
+        resolved = custom_provider.resolve_icon_name(name, auto_style)
+        super().__init__(resolved, padded_size, color)
+
+
 class DemoWithAnimation(AsyncWindow):
     """Compare synchronous vs asynchronous calls in Tk."""
 
@@ -1115,9 +1153,17 @@ def get_first_in_range(upper_bound: float, selection: dict) -> Any:  # noqa ANN4
     return first_value_in_range
 
 
-def image_from_icon(name: str, fill: str = "#000000", scale_to_width: int = 16, scale_to_height: int = 16) -> tk.PhotoImage:
-    """Look up a FontAwesome icon by name and return it as an PhotoImage object."""
-    return icon_to_image(name, fill, scale_to_width, scale_to_height, scale)
+def image_from_icon(
+    name: str, fill: str = "#000000", scale_to_width: int = 16, scale_to_height: int = 16
+) -> tk.PhotoImage:
+    """
+    Render a FontAwesome icon by name and return it as a tk.PhotoImage object.
+
+    'name' is taken from the solid subset unless it ends with -regular or -brands.
+    """
+    size = max(scale_to_height, scale_to_width)
+    font_awesome_icon = CustomFontAwesomeIcon(name, size=size, color=fill)
+    return font_awesome_icon.image
 
 
 def hex_string_for_style(style_name: str, theme_name: str = "") -> str:

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -3,6 +3,7 @@
 import asyncio
 import enum
 import functools
+import io
 import json
 import logging
 import pathlib
@@ -10,6 +11,7 @@ import subprocess
 import sys
 import tkinter as tk
 import webbrowser
+import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from dataclasses import dataclass
 from tkinter import font
@@ -18,6 +20,7 @@ from typing import Any, ClassVar, NamedTuple
 import click
 import matplotlib.axes as mpl_axes
 import matplotlib.backend_bases as mpl_backend_bases
+import tksvg
 import ttkbootstrap as ttk
 import ttkbootstrap.icons as ttk_icons
 import ttkbootstrap.style as ttk_style
@@ -1164,6 +1167,41 @@ def image_from_icon(
     size = max(scale_to_height, scale_to_width)
     font_awesome_icon = CustomFontAwesomeIcon(name, size=size, color=fill)
     return font_awesome_icon.image
+
+
+def image_from_svg(
+    svg_text: str, fill: str = "#000000", scale_to_width: int = 16, scale_to_height: int = 16
+) -> tk.PhotoImage:
+    """Render the SVG text into a tk.PhotoImage object using the fill and size information."""
+    # Reworked without lxml from
+    # https://github.com/israel-dryer/TkFontAwesome/blob/503c71e00dadd44abf3f9b74db49101c990f0f96/tkfontawesome/__init__.py#L42
+    ET.register_namespace("", "http://www.w3.org/2000/svg")
+    root = ET.fromstring(svg_text)  # noqa S314: this package does not parse user-files
+    tree = ET.ElementTree(root)
+
+    # Apply fill color
+    for elem in root.iter():
+        tag = str(elem.tag)
+        if "fill" in elem.attrib or tag.endswith("path"):
+            elem.attrib["fill"] = fill
+
+    # Calculate scale
+    desired_pixel_size = max(scale_to_width, scale_to_height)
+    x0, y0, x1, y1 = root.attrib["viewBox"].split(" ")
+    width = float(x1) - float(x0)
+    height = float(y1) - float(y0)
+    x_ratio = desired_pixel_size / width
+    y_ratio = desired_pixel_size / height
+    scale = x_ratio if desired_pixel_size == scale_to_width else y_ratio
+
+    img_data = io.BytesIO()
+    tree.write(img_data)
+    img_text_bytes = img_data.getvalue()
+    params = {
+        "data": img_text_bytes,
+        "scale": scale,
+    }
+    return tksvg.SvgImage(**params)
 
 
 def hex_string_for_style(style_name: str, theme_name: str = "") -> str:

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -1115,6 +1115,11 @@ def get_first_in_range(upper_bound: float, selection: dict) -> Any:  # noqa ANN4
     return first_value_in_range
 
 
+def image_from_icon(name: str, fill: str | None = None, scale_to_width: int | None = None, scale_to_height: int | None = None, scale: float = 1) -> tk.PhotoImage:
+    """Look up a FontAwesome icon by name and return it as an PhotoImage object."""
+    return icon_to_image(name, fill, scale_to_width, scale_to_height, scale)
+
+
 def hex_string_for_style(style_name: str, theme_name: str = "") -> str:
     """Return the '#RRGGBB' string for the specified style name for the active or specified theme."""
     if not theme_name:

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -363,7 +363,7 @@ class ActionDialog(AsyncDialog):
             image_name = "o"
         if not image_fill:
             image_fill = StyleKey.Fg
-        self.message_image = icon_to_image(name=image_name, fill=hex_string_for_style(image_fill), scale_to_height=40)
+        self.message_image = image_from_icon(name=image_name, fill=hex_string_for_style(image_fill), scale_to_height=40)
         if not message_paragraphs:
             message_paragraphs = ["Click OK to close."]
         self.message = "\n\n".join([click.wrap_text(message, width=64) for message in message_paragraphs])
@@ -482,7 +482,7 @@ class AboutDialog(AsyncDialog):
         separator.grid(column=1, row=3, columnspan=5, sticky=tk.EW, pady=4)
         button_text_color = hex_string_for_style(StyleKey.SelectFg)
         spacer = "   "
-        self.help_icon = icon_to_image("parachute-box", fill=button_text_color, scale_to_width=16)
+        self.help_icon = image_from_icon("parachute-box", fill=button_text_color, scale_to_width=16)
         help_button = ttk.Button(
             message_frame,
             compound=tk.LEFT,
@@ -493,7 +493,7 @@ class AboutDialog(AsyncDialog):
             command=functools.partial(webbrowser.open_new_tab, self.help_url),
         )
         help_button.grid(column=5, row=4, sticky=tk.W, pady=(18, 0))
-        self.source_icon = icon_to_image("github-alt", fill=button_text_color, scale_to_width=16)
+        self.source_icon = image_from_icon("github-alt", fill=button_text_color, scale_to_width=16)
         source_button = ttk.Button(
             message_frame,
             compound=tk.LEFT,
@@ -530,7 +530,7 @@ class AboutDialog(AsyncDialog):
         icon_color = hex_string_for_style(StyleKey.Fg)
         self.app_icon_images.clear()
         for icon_name, icon_label in zip(self.app_icons, self.icon_labels, strict=True):
-            icon_image = icon_to_image(icon_name, fill=icon_color, scale_to_height=icon_height)
+            icon_image = image_from_icon(icon_name, fill=icon_color, scale_to_height=icon_height)
             self.app_icon_images.append(icon_image)
             icon_label.configure(image=icon_image)
 

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -427,7 +427,7 @@ class AboutDialog(AsyncDialog):
         self.app_icons = all_icons[:3]
         self.icon_labels = []
         self.app_icon_images = []
-        self.help_url = help_url or datatypes.Links.Homepage
+        self.help_url = help_url or datatypes.Links.Help
         self.source_url = source_url or datatypes.Links.Source
         self.copy_version_text = "Copy version"
         super().__init__(parent, f"About {app_name}".strip())

--- a/src/qtpy_datalogger/guikit.py
+++ b/src/qtpy_datalogger/guikit.py
@@ -1115,7 +1115,7 @@ def get_first_in_range(upper_bound: float, selection: dict) -> Any:  # noqa ANN4
     return first_value_in_range
 
 
-def image_from_icon(name: str, fill: str | None = None, scale_to_width: int | None = None, scale_to_height: int | None = None) -> tk.PhotoImage:
+def image_from_icon(name: str, fill: str = "#000000", scale_to_width: int = 16, scale_to_height: int = 16) -> tk.PhotoImage:
     """Look up a FontAwesome icon by name and return it as an PhotoImage object."""
     return icon_to_image(name, fill, scale_to_width, scale_to_height, scale)
 

--- a/tests/test_guikit.py
+++ b/tests/test_guikit.py
@@ -1,0 +1,11 @@
+"""Tests for the guikit module."""
+
+import tkinter as tk
+
+from qtpy_datalogger import guikit
+
+
+def test_can_use_font_awesome_icons() -> None:
+    """Do the custom overrides for ttkbootstrap_icons succeed?"""
+    _ = tk.Tk()
+    _ = guikit.image_from_icon("worm")

--- a/uv.lock
+++ b/uv.lock
@@ -1425,6 +1425,7 @@ dependencies = [
     { name = "pandas" },
     { name = "psutil" },
     { name = "pyserial" },
+    { name = "tksvg" },
     { name = "ttkbootstrap" },
     { name = "ttkbootstrap-icons" },
     { name = "ttkbootstrap-icons-fa" },
@@ -1458,6 +1459,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.2" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "pyserial", specifier = ">=3.5" },
+    { name = "tksvg", specifier = ">=0.7.4" },
     { name = "ttkbootstrap", specifier = ">=1.20.2" },
     { name = "ttkbootstrap-icons", specifier = ">=4.0.0" },
     { name = "ttkbootstrap-icons-fa", specifier = ">=1.0.2" },
@@ -1569,6 +1571,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/13/a49595e0056dc607e7530b946c7b62f11ec514822c40d54d94287e534e9d/sysv_ipc-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a65e64577082b109d49bd68db8facb6f3a08ddbbde4b76c87b1246490922ef2a", size = 75679, upload-time = "2026-01-09T14:04:44.4Z" },
     { url = "https://files.pythonhosted.org/packages/82/89/6ab21a4568e65630385a715a8c8f9019e1a21cf1d57ba3e7358c62d14d63/sysv_ipc-1.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:966f685dd9dc5c5862edada5fc8de70dc5f5659a89c0698366431a81931179a9", size = 25207, upload-time = "2026-01-09T14:05:00.635Z" },
     { url = "https://files.pythonhosted.org/packages/f3/df/a6f6a945a69ad796c7de91e489aeecb6a9b6d3437f8c927f3ad3194d9cc5/sysv_ipc-1.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae2d070b842bb4558aeb6aec7249ec7f08d00d8252e37da24cccab8057efeb29", size = 25011, upload-time = "2026-01-09T14:05:01.459Z" },
+]
+
+[[package]]
+name = "tksvg"
+version = "0.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/73/39960696fa563162edcf21bef52453cc7cfb965a0bb1e413730237de0aa3/tksvg-0.7.4.tar.gz", hash = "sha256:e451c4301814306547afca80680e6db0cc6720b7d6cc3dca56beb17c2b29c0f5", size = 50395, upload-time = "2021-08-02T13:54:43.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/31/bb2da3f9ea480b273d3319430e24bb74e8b202fb8a90fa0a3689b9e5c51f/tksvg-0.7.4-py3-none-win_amd64.whl", hash = "sha256:1e96830e3e92d12390aee3460dab2aab169bd3b1cb59ba478329c1e6bc3edd2a", size = 173345, upload-time = "2021-08-02T13:54:42.616Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -680,65 +680,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lxml"
-version = "5.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz", hash = "sha256:d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd", size = 3679479, upload-time = "2025-04-23T01:50:29.322Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/2d/67693cc8a605a12e5975380d7ff83020dcc759351b5a066e1cced04f797b/lxml-5.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:98a3912194c079ef37e716ed228ae0dcb960992100461b704aea4e93af6b0bb9", size = 8083240, upload-time = "2025-04-23T01:45:18.566Z" },
-    { url = "https://files.pythonhosted.org/packages/73/53/b5a05ab300a808b72e848efd152fe9c022c0181b0a70b8bca1199f1bed26/lxml-5.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ea0252b51d296a75f6118ed0d8696888e7403408ad42345d7dfd0d1e93309a7", size = 4387685, upload-time = "2025-04-23T01:45:21.387Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cb/1a3879c5f512bdcd32995c301886fe082b2edd83c87d41b6d42d89b4ea4d/lxml-5.4.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b92b69441d1bd39f4940f9eadfa417a25862242ca2c396b406f9272ef09cdcaa", size = 4991164, upload-time = "2025-04-23T01:45:23.849Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/94/bbc66e42559f9d04857071e3b3d0c9abd88579367fd2588a4042f641f57e/lxml-5.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20e16c08254b9b6466526bc1828d9370ee6c0d60a4b64836bc3ac2917d1e16df", size = 4746206, upload-time = "2025-04-23T01:45:26.361Z" },
-    { url = "https://files.pythonhosted.org/packages/66/95/34b0679bee435da2d7cae895731700e519a8dfcab499c21662ebe671603e/lxml-5.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7605c1c32c3d6e8c990dd28a0970a3cbbf1429d5b92279e37fda05fb0c92190e", size = 5342144, upload-time = "2025-04-23T01:45:28.939Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/5d/abfcc6ab2fa0be72b2ba938abdae1f7cad4c632f8d552683ea295d55adfb/lxml-5.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ecf4c4b83f1ab3d5a7ace10bafcb6f11df6156857a3c418244cef41ca9fa3e44", size = 4825124, upload-time = "2025-04-23T01:45:31.361Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/78/6bd33186c8863b36e084f294fc0a5e5eefe77af95f0663ef33809cc1c8aa/lxml-5.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cef4feae82709eed352cd7e97ae062ef6ae9c7b5dbe3663f104cd2c0e8d94ba", size = 4876520, upload-time = "2025-04-23T01:45:34.191Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/74/4d7ad4839bd0fc64e3d12da74fc9a193febb0fae0ba6ebd5149d4c23176a/lxml-5.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:df53330a3bff250f10472ce96a9af28628ff1f4efc51ccba351a8820bca2a8ba", size = 4765016, upload-time = "2025-04-23T01:45:36.7Z" },
-    { url = "https://files.pythonhosted.org/packages/24/0d/0a98ed1f2471911dadfc541003ac6dd6879fc87b15e1143743ca20f3e973/lxml-5.4.0-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:aefe1a7cb852fa61150fcb21a8c8fcea7b58c4cb11fbe59c97a0a4b31cae3c8c", size = 5362884, upload-time = "2025-04-23T01:45:39.291Z" },
-    { url = "https://files.pythonhosted.org/packages/48/de/d4f7e4c39740a6610f0f6959052b547478107967362e8424e1163ec37ae8/lxml-5.4.0-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:ef5a7178fcc73b7d8c07229e89f8eb45b2908a9238eb90dcfc46571ccf0383b8", size = 4902690, upload-time = "2025-04-23T01:45:42.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/8c/61763abd242af84f355ca4ef1ee096d3c1b7514819564cce70fd18c22e9a/lxml-5.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d2ed1b3cb9ff1c10e6e8b00941bb2e5bb568b307bfc6b17dffbbe8be5eecba86", size = 4944418, upload-time = "2025-04-23T01:45:46.051Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/6d7e3b63e7e282619193961a570c0a4c8a57fe820f07ca3fe2f6bd86608a/lxml-5.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:72ac9762a9f8ce74c9eed4a4e74306f2f18613a6b71fa065495a67ac227b3056", size = 4827092, upload-time = "2025-04-23T01:45:48.943Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4a/e60a306df54680b103348545706a98a7514a42c8b4fbfdcaa608567bb065/lxml-5.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f5cb182f6396706dc6cc1896dd02b1c889d644c081b0cdec38747573db88a7d7", size = 5418231, upload-time = "2025-04-23T01:45:51.481Z" },
-    { url = "https://files.pythonhosted.org/packages/27/f2/9754aacd6016c930875854f08ac4b192a47fe19565f776a64004aa167521/lxml-5.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:3a3178b4873df8ef9457a4875703488eb1622632a9cee6d76464b60e90adbfcd", size = 5261798, upload-time = "2025-04-23T01:45:54.146Z" },
-    { url = "https://files.pythonhosted.org/packages/38/a2/0c49ec6941428b1bd4f280650d7b11a0f91ace9db7de32eb7aa23bcb39ff/lxml-5.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e094ec83694b59d263802ed03a8384594fcce477ce484b0cbcd0008a211ca751", size = 4988195, upload-time = "2025-04-23T01:45:56.685Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/75/87a3963a08eafc46a86c1131c6e28a4de103ba30b5ae903114177352a3d7/lxml-5.4.0-cp311-cp311-win32.whl", hash = "sha256:4329422de653cdb2b72afa39b0aa04252fca9071550044904b2e7036d9d97fe4", size = 3474243, upload-time = "2025-04-23T01:45:58.863Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/1f0964c4f6c2be861c50db380c554fb8befbea98c6404744ce243a3c87ef/lxml-5.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd3be6481ef54b8cfd0e1e953323b7aa9d9789b94842d0e5b142ef4bb7999539", size = 3815197, upload-time = "2025-04-23T01:46:01.096Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/4c/d101ace719ca6a4ec043eb516fcfcb1b396a9fccc4fcd9ef593df34ba0d5/lxml-5.4.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b5aff6f3e818e6bdbbb38e5967520f174b18f539c2b9de867b1e7fde6f8d95a4", size = 8127392, upload-time = "2025-04-23T01:46:04.09Z" },
-    { url = "https://files.pythonhosted.org/packages/11/84/beddae0cec4dd9ddf46abf156f0af451c13019a0fa25d7445b655ba5ccb7/lxml-5.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:942a5d73f739ad7c452bf739a62a0f83e2578afd6b8e5406308731f4ce78b16d", size = 4415103, upload-time = "2025-04-23T01:46:07.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/25/d0d93a4e763f0462cccd2b8a665bf1e4343dd788c76dcfefa289d46a38a9/lxml-5.4.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:460508a4b07364d6abf53acaa0a90b6d370fafde5693ef37602566613a9b0779", size = 5024224, upload-time = "2025-04-23T01:46:10.237Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ce/1df18fb8f7946e7f3388af378b1f34fcf253b94b9feedb2cec5969da8012/lxml-5.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:529024ab3a505fed78fe3cc5ddc079464e709f6c892733e3f5842007cec8ac6e", size = 4769913, upload-time = "2025-04-23T01:46:12.757Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/62/f4a6c60ae7c40d43657f552f3045df05118636be1165b906d3423790447f/lxml-5.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ca56ebc2c474e8f3d5761debfd9283b8b18c76c4fc0967b74aeafba1f5647f9", size = 5290441, upload-time = "2025-04-23T01:46:16.037Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/aa/04f00009e1e3a77838c7fc948f161b5d2d5de1136b2b81c712a263829ea4/lxml-5.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a81e1196f0a5b4167a8dafe3a66aa67c4addac1b22dc47947abd5d5c7a3f24b5", size = 4820165, upload-time = "2025-04-23T01:46:19.137Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/e0b2f61fa2404bf0f1fdf1898377e5bd1b74cc9b2cf2c6ba8509b8f27990/lxml-5.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00b8686694423ddae324cf614e1b9659c2edb754de617703c3d29ff568448df5", size = 4932580, upload-time = "2025-04-23T01:46:21.963Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a2/8263f351b4ffe0ed3e32ea7b7830f845c795349034f912f490180d88a877/lxml-5.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c5681160758d3f6ac5b4fea370495c48aac0989d6a0f01bb9a72ad8ef5ab75c4", size = 4759493, upload-time = "2025-04-23T01:46:24.316Z" },
-    { url = "https://files.pythonhosted.org/packages/05/00/41db052f279995c0e35c79d0f0fc9f8122d5b5e9630139c592a0b58c71b4/lxml-5.4.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:2dc191e60425ad70e75a68c9fd90ab284df64d9cd410ba8d2b641c0c45bc006e", size = 5324679, upload-time = "2025-04-23T01:46:27.097Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/be/ee99e6314cdef4587617d3b3b745f9356d9b7dd12a9663c5f3b5734b64ba/lxml-5.4.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:67f779374c6b9753ae0a0195a892a1c234ce8416e4448fe1e9f34746482070a7", size = 4890691, upload-time = "2025-04-23T01:46:30.009Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/36/239820114bf1d71f38f12208b9c58dec033cbcf80101cde006b9bde5cffd/lxml-5.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:79d5bfa9c1b455336f52343130b2067164040604e41f6dc4d8313867ed540079", size = 4955075, upload-time = "2025-04-23T01:46:32.33Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e1/1b795cc0b174efc9e13dbd078a9ff79a58728a033142bc6d70a1ee8fc34d/lxml-5.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3d3c30ba1c9b48c68489dc1829a6eede9873f52edca1dda900066542528d6b20", size = 4838680, upload-time = "2025-04-23T01:46:34.852Z" },
-    { url = "https://files.pythonhosted.org/packages/72/48/3c198455ca108cec5ae3662ae8acd7fd99476812fd712bb17f1b39a0b589/lxml-5.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1af80c6316ae68aded77e91cd9d80648f7dd40406cef73df841aa3c36f6907c8", size = 5391253, upload-time = "2025-04-23T01:46:37.608Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/10/5bf51858971c51ec96cfc13e800a9951f3fd501686f4c18d7d84fe2d6352/lxml-5.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4d885698f5019abe0de3d352caf9466d5de2baded00a06ef3f1216c1a58ae78f", size = 5261651, upload-time = "2025-04-23T01:46:40.183Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/11/06710dd809205377da380546f91d2ac94bad9ff735a72b64ec029f706c85/lxml-5.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aea53d51859b6c64e7c51d522c03cc2c48b9b5d6172126854cc7f01aa11f52bc", size = 5024315, upload-time = "2025-04-23T01:46:43.333Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/b0/15b6217834b5e3a59ebf7f53125e08e318030e8cc0d7310355e6edac98ef/lxml-5.4.0-cp312-cp312-win32.whl", hash = "sha256:d90b729fd2732df28130c064aac9bb8aff14ba20baa4aee7bd0795ff1187545f", size = 3486149, upload-time = "2025-04-23T01:46:45.684Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1e/05ddcb57ad2f3069101611bd5f5084157d90861a2ef460bf42f45cced944/lxml-5.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1dc4ca99e89c335a7ed47d38964abcb36c5910790f9bd106f2a8fa2ee0b909d2", size = 3817095, upload-time = "2025-04-23T01:46:48.521Z" },
-    { url = "https://files.pythonhosted.org/packages/87/cb/2ba1e9dd953415f58548506fa5549a7f373ae55e80c61c9041b7fd09a38a/lxml-5.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:773e27b62920199c6197130632c18fb7ead3257fce1ffb7d286912e56ddb79e0", size = 8110086, upload-time = "2025-04-23T01:46:52.218Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/3e/6602a4dca3ae344e8609914d6ab22e52ce42e3e1638c10967568c5c1450d/lxml-5.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ce9c671845de9699904b1e9df95acfe8dfc183f2310f163cdaa91a3535af95de", size = 4404613, upload-time = "2025-04-23T01:46:55.281Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/72/bf00988477d3bb452bef9436e45aeea82bb40cdfb4684b83c967c53909c7/lxml-5.4.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9454b8d8200ec99a224df8854786262b1bd6461f4280064c807303c642c05e76", size = 5012008, upload-time = "2025-04-23T01:46:57.817Z" },
-    { url = "https://files.pythonhosted.org/packages/92/1f/93e42d93e9e7a44b2d3354c462cd784dbaaf350f7976b5d7c3f85d68d1b1/lxml-5.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cccd007d5c95279e529c146d095f1d39ac05139de26c098166c4beb9374b0f4d", size = 4760915, upload-time = "2025-04-23T01:47:00.745Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0b/363009390d0b461cf9976a499e83b68f792e4c32ecef092f3f9ef9c4ba54/lxml-5.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0fce1294a0497edb034cb416ad3e77ecc89b313cff7adbee5334e4dc0d11f422", size = 5283890, upload-time = "2025-04-23T01:47:04.702Z" },
-    { url = "https://files.pythonhosted.org/packages/19/dc/6056c332f9378ab476c88e301e6549a0454dbee8f0ae16847414f0eccb74/lxml-5.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24974f774f3a78ac12b95e3a20ef0931795ff04dbb16db81a90c37f589819551", size = 4812644, upload-time = "2025-04-23T01:47:07.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8a/f8c66bbb23ecb9048a46a5ef9b495fd23f7543df642dabeebcb2eeb66592/lxml-5.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:497cab4d8254c2a90bf988f162ace2ddbfdd806fce3bda3f581b9d24c852e03c", size = 4921817, upload-time = "2025-04-23T01:47:10.317Z" },
-    { url = "https://files.pythonhosted.org/packages/04/57/2e537083c3f381f83d05d9b176f0d838a9e8961f7ed8ddce3f0217179ce3/lxml-5.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e794f698ae4c5084414efea0f5cc9f4ac562ec02d66e1484ff822ef97c2cadff", size = 4753916, upload-time = "2025-04-23T01:47:12.823Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/80/ea8c4072109a350848f1157ce83ccd9439601274035cd045ac31f47f3417/lxml-5.4.0-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:2c62891b1ea3094bb12097822b3d44b93fc6c325f2043c4d2736a8ff09e65f60", size = 5289274, upload-time = "2025-04-23T01:47:15.916Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/47/c4be287c48cdc304483457878a3f22999098b9a95f455e3c4bda7ec7fc72/lxml-5.4.0-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:142accb3e4d1edae4b392bd165a9abdee8a3c432a2cca193df995bc3886249c8", size = 4874757, upload-time = "2025-04-23T01:47:19.793Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/04/6ef935dc74e729932e39478e44d8cfe6a83550552eaa072b7c05f6f22488/lxml-5.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1a42b3a19346e5601d1b8296ff6ef3d76038058f311902edd574461e9c036982", size = 4947028, upload-time = "2025-04-23T01:47:22.401Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f9/c33fc8daa373ef8a7daddb53175289024512b6619bc9de36d77dca3df44b/lxml-5.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4291d3c409a17febf817259cb37bc62cb7eb398bcc95c1356947e2871911ae61", size = 4834487, upload-time = "2025-04-23T01:47:25.513Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/30/fc92bb595bcb878311e01b418b57d13900f84c2b94f6eca9e5073ea756e6/lxml-5.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4f5322cf38fe0e21c2d73901abf68e6329dc02a4994e483adbcf92b568a09a54", size = 5381688, upload-time = "2025-04-23T01:47:28.454Z" },
-    { url = "https://files.pythonhosted.org/packages/43/d1/3ba7bd978ce28bba8e3da2c2e9d5ae3f8f521ad3f0ca6ea4788d086ba00d/lxml-5.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:0be91891bdb06ebe65122aa6bf3fc94489960cf7e03033c6f83a90863b23c58b", size = 5242043, upload-time = "2025-04-23T01:47:31.208Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/cd/95fa2201041a610c4d08ddaf31d43b98ecc4b1d74b1e7245b1abdab443cb/lxml-5.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:15a665ad90054a3d4f397bc40f73948d48e36e4c09f9bcffc7d90c87410e478a", size = 5021569, upload-time = "2025-04-23T01:47:33.805Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/a6/31da006fead660b9512d08d23d31e93ad3477dd47cc42e3285f143443176/lxml-5.4.0-cp313-cp313-win32.whl", hash = "sha256:d5663bc1b471c79f5c833cffbc9b87d7bf13f87e055a5c86c363ccd2348d7e82", size = 3485270, upload-time = "2025-04-23T01:47:36.133Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/14/c115516c62a7d2499781d2d3d7215218c0731b2c940753bf9f9b7b73924d/lxml-5.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:bcb7a1096b4b6b24ce1ac24d4942ad98f983cd3810f9711bcd0293f43a9d8b9f", size = 3814606, upload-time = "2025-04-23T01:47:39.028Z" },
-]
-
-[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1484,7 +1425,6 @@ dependencies = [
     { name = "pandas" },
     { name = "psutil" },
     { name = "pyserial" },
-    { name = "tkfontawesome" },
     { name = "ttkbootstrap" },
     { name = "ttkbootstrap-icons" },
     { name = "ttkbootstrap-icons-fa" },
@@ -1518,7 +1458,6 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.2" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "pyserial", specifier = ">=3.5" },
-    { name = "tkfontawesome", specifier = ">=0.3.2" },
     { name = "ttkbootstrap", specifier = ">=1.20.2" },
     { name = "ttkbootstrap-icons", specifier = ">=4.0.0" },
     { name = "ttkbootstrap-icons-fa", specifier = ">=1.0.2" },
@@ -1630,28 +1569,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/13/a49595e0056dc607e7530b946c7b62f11ec514822c40d54d94287e534e9d/sysv_ipc-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a65e64577082b109d49bd68db8facb6f3a08ddbbde4b76c87b1246490922ef2a", size = 75679, upload-time = "2026-01-09T14:04:44.4Z" },
     { url = "https://files.pythonhosted.org/packages/82/89/6ab21a4568e65630385a715a8c8f9019e1a21cf1d57ba3e7358c62d14d63/sysv_ipc-1.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:966f685dd9dc5c5862edada5fc8de70dc5f5659a89c0698366431a81931179a9", size = 25207, upload-time = "2026-01-09T14:05:00.635Z" },
     { url = "https://files.pythonhosted.org/packages/f3/df/a6f6a945a69ad796c7de91e489aeecb6a9b6d3437f8c927f3ad3194d9cc5/sysv_ipc-1.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae2d070b842bb4558aeb6aec7249ec7f08d00d8252e37da24cccab8057efeb29", size = 25011, upload-time = "2026-01-09T14:05:01.459Z" },
-]
-
-[[package]]
-name = "tkfontawesome"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lxml" },
-    { name = "tksvg" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/9d/13464ad97c6440234da802db4f681386341d8f78f4823c459dcb15c8bfb0/tkfontawesome-0.3.2.tar.gz", hash = "sha256:8286d8be06d537e18bc670a0211b13af222ac564d6e0211608dfff97653eefde", size = 480398, upload-time = "2025-05-04T03:07:50.563Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/60/cb35ababbb3fd09eb0e7b9008e9a787cc77c553a2811280cd5d0068f6601/tkfontawesome-0.3.2-py3-none-any.whl", hash = "sha256:12b56d86206c5fc719012f5770f40d408da7acd59f6ea08bc07ce5cd921fab2a", size = 480810, upload-time = "2025-05-04T03:07:48.659Z" },
-]
-
-[[package]]
-name = "tksvg"
-version = "0.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/73/39960696fa563162edcf21bef52453cc7cfb965a0bb1e413730237de0aa3/tksvg-0.7.4.tar.gz", hash = "sha256:e451c4301814306547afca80680e6db0cc6720b7d6cc3dca56beb17c2b29c0f5", size = 50395, upload-time = "2021-08-02T13:54:43.507Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/31/bb2da3f9ea480b273d3319430e24bb74e8b202fb8a90fa0a3689b9e5c51f/tksvg-0.7.4-py3-none-win_amd64.whl", hash = "sha256:1e96830e3e92d12390aee3460dab2aab169bd3b1cb59ba478329c1e6bc3edd2a", size = 173345, upload-time = "2021-08-02T13:54:42.616Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1486,6 +1486,7 @@ dependencies = [
     { name = "pyserial" },
     { name = "tkfontawesome" },
     { name = "ttkbootstrap" },
+    { name = "ttkbootstrap-icons" },
     { name = "wmi" },
 ]
 
@@ -1518,6 +1519,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "tkfontawesome", specifier = ">=0.3.2" },
     { name = "ttkbootstrap", specifier = ">=1.20.2" },
+    { name = "ttkbootstrap-icons", specifier = ">=4.0.0" },
     { name = "wmi", specifier = ">=1.5.1" },
 ]
 
@@ -1723,6 +1725,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/88/bb1535edbd12e7b60223bee86241368b5d27043c001ef81d620ae8a56faf/ttkbootstrap-1.20.3.tar.gz", hash = "sha256:3350b80f79b0454c12558a7174c4bc4bd47905758843c3e8b0fbb19a0286fb69", size = 176262, upload-time = "2026-05-07T03:09:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/48/a5fd0d5d360e363f9bb289bef29b66103fd4ae1be1e3b6896a01b6e0f993/ttkbootstrap-1.20.3-py3-none-any.whl", hash = "sha256:95a05a4a663e3047be54edc220aa59c494a54f5c617a72a2c59a4bf634b97a5a", size = 191453, upload-time = "2026-05-07T03:09:24.935Z" },
+]
+
+[[package]]
+name = "ttkbootstrap-icons"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/ac/19312258e408ba8c708256fd948bc78ab7d1d944991adfaf4044d56b7c78/ttkbootstrap_icons-4.0.0.tar.gz", hash = "sha256:4d3045e053fa57ce1cc6524d8cd721715595114803cc362616d7cdc8a2a9c416", size = 90441, upload-time = "2025-12-05T04:34:15.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7e/f610e3d08fc64c419ff6a0c6d0b168e0fe15ad181f45f51ef37ea3f434b7/ttkbootstrap_icons-4.0.0-py3-none-any.whl", hash = "sha256:75ac2a2205be559a348bc6df037976f02e9a0cf4058e3ed037ddf2520dfa8cfd", size = 33743, upload-time = "2025-12-05T04:34:14.708Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1487,6 +1487,7 @@ dependencies = [
     { name = "tkfontawesome" },
     { name = "ttkbootstrap" },
     { name = "ttkbootstrap-icons" },
+    { name = "ttkbootstrap-icons-fa" },
     { name = "wmi" },
 ]
 
@@ -1520,6 +1521,7 @@ requires-dist = [
     { name = "tkfontawesome", specifier = ">=0.3.2" },
     { name = "ttkbootstrap", specifier = ">=1.20.2" },
     { name = "ttkbootstrap-icons", specifier = ">=4.0.0" },
+    { name = "ttkbootstrap-icons-fa", specifier = ">=1.0.2" },
     { name = "wmi", specifier = ">=1.5.1" },
 ]
 
@@ -1738,6 +1740,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/ac/19312258e408ba8c708256fd948bc78ab7d1d944991adfaf4044d56b7c78/ttkbootstrap_icons-4.0.0.tar.gz", hash = "sha256:4d3045e053fa57ce1cc6524d8cd721715595114803cc362616d7cdc8a2a9c416", size = 90441, upload-time = "2025-12-05T04:34:15.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/7e/f610e3d08fc64c419ff6a0c6d0b168e0fe15ad181f45f51ef37ea3f434b7/ttkbootstrap_icons-4.0.0-py3-none-any.whl", hash = "sha256:75ac2a2205be559a348bc6df037976f02e9a0cf4058e3ed037ddf2520dfa8cfd", size = 33743, upload-time = "2025-12-05T04:34:14.708Z" },
+]
+
+[[package]]
+name = "ttkbootstrap-icons-fa"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+    { name = "ttkbootstrap-icons" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/a6/0d8c349bf6bf91fe492b771f2f88538228fc13f274f952aa8a31b239587c/ttkbootstrap_icons_fa-1.0.2.tar.gz", hash = "sha256:74e1c95606cebd6f791bd8aff6fec57c0109b5f466c20fbb46a526b585de0a62", size = 343551, upload-time = "2025-11-17T06:33:27.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/06/e68f16e7b08a9f2fb4762d53e925528bd3376279b60f86790ea44a5c26c5/ttkbootstrap_icons_fa-1.0.2-py3-none-any.whl", hash = "sha256:1a7ecdef7ee3c1d5d5583a0d7555197c6c5e204658a22fce60516191075c873f", size = 345803, upload-time = "2025-11-17T06:33:25.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR removes **`tkfontawesome`** and replaces it with **`ttkbootstrap_icons`**, which is the [maintainer's recommendation](https://github.com/israel-dryer/TkFontAwesome/blob/main/README.md#prefer-ttkbootstrap-icons).

This also unblocks **Python 3.14** support, so enable testing for that version in the CI workflow.

## Design

**`guikit.py`**
- Add new helper function **`image_from_icon()`**: render a FontAwesome icon by name and return it as a tk.PhotoImage object
  - Use `CustomFontAwesomeIcon` to override the `ttkbootstrap_icons-fa` rendering options
  - Set **`pad_factor`** to **0** so the icons render at the requested size
  - Adjust **`y_bias`** so the icons are not visually clipped
- Add new helper function **`image_from_svg()`**: render the SVG text into a tk.PhotoImage object
  - Use the built-in XML parser rather than `lxml`
  - Add the `fill` property to tree elements
  - Calculate and set the scale factor to match requested size
- Use **`image_from_icon()`** instead of **`tkfontawesome.icon_to_image()`**
- Change the _Online help_ button URL to the Help welcome page

**`datatypes.py`**
- Add new **Links** enum value for the **Help** page

**`__init__.py`**
- Broaden the warning filter

**`scanner.py`**
- Use **`guikit.image_from_svg()`** instead of **`tkfontawesome.svg_to_image()`**

**`data_viewer.py`**
- Use **`guikit.image_from_icon()`** instead of **`tkfontawesome.icon_to_image()`**

**`test_guikit.py`**
- Add test to validate the custom FontAwesome provider

**`ci.yml`**
- Enable **Python 3.14** testing in the test strategy matrix

**`pyproject.toml`**
- Add **`ttkbootstrap_icons`** and **`ttkbootstrap_icons-fa`** to use FontAwesome glyphs
- Add **`tksvg`** to use SVG drawings
- Remove **`tkfontawesome`** to eliminate the dependency on [vulnerable **`lxml 5.4`**](https://github.com/wireddown/qtpy-datalogger/security/dependabot/15)

**`.gitignore`**
- Add **.python-version** to allow using any Python version locally

## Screenshots or logs

These screenshots were taken with a **Python 3.14** virtual environment. They also show that the font icons and SVG files still render correctly.

---

### Data Viewer

- This app uses **FontAwesome** icons

<img width="1170" height="796" alt="icons-py314-dataviewer-1" src="https://github.com/user-attachments/assets/e5582bfc-daa4-4b16-92e1-75d5813b2b04" />

<img width="1170" height="796" alt="icons-py314-dataviewer-2" src="https://github.com/user-attachments/assets/6f11f64b-7038-4419-9150-de4ce2d84485" />

---

### Scanner

- This app uses **custom SVG assets**

<img width="638" height="604" alt="icons-py314-scanner" src="https://github.com/user-attachments/assets/15994f88-4029-4090-b9b2-60888a6f37b0" />

## Testing

- The visual checks are above
- I was able to use the `equip` command with Python 3.14
- The CI workflow now tests with Python 3.14

## Checklist

- [x] ~~Issues linked / labels applied~~
- [ ] Documentation updated
- [x] Tests added / updated / removed
- [x] Tests passed
- [x] Analyzers passed
- [x] Ready to complete
